### PR TITLE
add weibo cookie edition

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -77,6 +77,15 @@ function createTray () {
           }
         },
         {
+          label: '微博Cookie图床',
+          type: 'radio',
+          checked: db.read().get('picBed.current').value() === 'weiboCookie',
+          click () {
+            db.read().set('picBed.current', 'weiboCookie')
+              .write()
+          }
+        },
+        {
           label: '七牛图床',
           type: 'radio',
           checked: db.read().get('picBed.current').value() === 'qiniu',

--- a/src/main/utils/uploader.js
+++ b/src/main/utils/uploader.js
@@ -1,4 +1,5 @@
 import weiboUpload from './weiboUpload'
+import weiboCookieUpload from './weiboCookieUpload'
 import qiniuUpload from './qiniuUpload'
 import tcYunUpload from './tcYunUpload'
 import upYunUpload from './upYunUpload'
@@ -19,6 +20,8 @@ const uploader = (img, type, webContents) => {
     switch (uploadType) {
       case 'weibo':
         return weiboUpload(img, type, webContents)
+      case 'weiboCookie':
+        return weiboCookieUpload(img, type, webContents)
       case 'qiniu':
         return qiniuUpload(img, type, webContents)
       case 'tcyun':

--- a/src/main/utils/weiboCookieUpload.js
+++ b/src/main/utils/weiboCookieUpload.js
@@ -1,0 +1,41 @@
+import request from 'request-promise'
+import * as img2Base64 from './img2base64'
+import db from '../../datastore/index'
+import { Notification } from 'electron'
+const UPLOAD_URL = 'http://picupload.service.weibo.com/interface/pic_upload.php?ori=1&mime=image%2Fjpeg&data=base64&url=0&markpos=1&logo=&nick=0&marks=1&app=miniblog'
+const weiboUpload = async function (img, type, webContents) {
+  try {
+    webContents.send('uploadProgress', 0)
+    const quality = db.read().get('picBed.weiboCookie.quality').value()
+    const cookie = db.read().get('picBed.weiboCookie.cookie').value()
+    webContents.send('uploadProgress', 60)
+    const imgList = await img2Base64[type](img)
+    for (let i in imgList) {
+      let result = await request.post(UPLOAD_URL, {
+        headers: {
+          Cookie: cookie
+        },
+        formData: {
+          b64_data: imgList[i].base64Image
+        }
+      })
+      result = result.replace(/<.*?\/>/, '').replace(/<(\w+).*?>.*?<\/\1>/, '')
+      delete imgList[i].base64Image
+      const resTextJson = JSON.parse(result)
+      imgList[i]['imgUrl'] = `https://ws1.sinaimg.cn/${quality}/${resTextJson.data.pics.pic_1.pid}`
+      imgList[i]['type'] = 'weibo'
+    }
+    webContents.send('uploadProgress', 100)
+    return imgList
+  } catch (err) {
+    webContents.send('uploadProgress', -1)
+    const notification = new Notification({
+      title: '上传失败！',
+      body: '服务端出错，请重试'
+    })
+    notification.show()
+    throw new Error(err)
+  }
+}
+
+export default weiboUpload

--- a/src/renderer/components/SettingPage.vue
+++ b/src/renderer/components/SettingPage.vue
@@ -26,6 +26,10 @@
             <i class="el-icon-ui-weibo"></i>
             <span slot="title">微博设置</span>
           </el-menu-item>
+          <el-menu-item index="weibo-cookie">
+            <i class="el-icon-ui-weibo"></i>
+            <span slot="title">微博Cookie设置</span>
+          </el-menu-item>
           <el-menu-item index="qiniu">
             <i class="el-icon-ui-qiniu"></i>
             <span slot="title">七牛云设置</span>

--- a/src/renderer/components/SettingView/WeiboCookie.vue
+++ b/src/renderer/components/SettingView/WeiboCookie.vue
@@ -1,0 +1,106 @@
+<template>
+  <div id="weibo-view">
+    <el-row :gutter="16">
+      <el-col :span="12" :offset="6">
+        <div class="view-title">
+          微博图床设置
+        </div>
+        <el-form 
+          ref="weiboForm"
+          label-position="top"
+          label-width="80px"
+          :model="form">
+          <el-form-item
+            label="设定微博cookie"
+            prop="cookie"
+            :rules="{
+              required: true, message: 'Cookie不能为空', trigger: 'blur'
+            }">
+            <el-input v-model="form.cookie" placeholder="Cookie" @keyup.native.enter="confirm('weiboForm')"></el-input>
+          </el-form-item>
+<!--           <el-form-item
+            label="设定密码"
+            prop="password"
+            :rules="{
+              required: true, message: '密码不能为空', trigger: 'blur'
+            }">
+            <el-input v-model="form.password" type="password" @keyup.native.enter="confirm('weiboForm')" placeholder="密码"></el-input>
+          </el-form-item> -->
+          <el-form-item label="* 图片质量">
+            <el-radio-group v-model="quality">
+              <el-radio label="thumbnail">缩略图</el-radio>
+              <el-radio label="mw690">中等尺寸</el-radio>
+              <el-radio label="large">原图</el-radio>
+            </el-radio-group>
+          </el-form-item>
+          <el-form-item>
+            <el-button type="primary" @click="confirm('weiboForm')" round>确定</el-button>
+          </el-form-item>
+        </el-form>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+<script>
+import mixin from '../mixin'
+export default {
+  name: 'weiboCookie',
+  mixins: [mixin],
+  data () {
+    return {
+      form: {
+        cookie: ''
+      },
+      quality: 'large'
+    }
+  },
+  created () {
+    const config = this.$db.read().get('picBed.weiboCookie').value()
+    if (config) {
+      this.form.cookie = config.cookie
+      this.quality = config.quality || 'large'
+    }
+  },
+  methods: {
+    confirm (formName) {
+      this.$refs[formName].validate((valid) => {
+        if (valid) {
+          this.$db.read().set('picBed.weiboCookie', {
+            cookie: this.form.cookie,
+            quality: this.quality
+          }).write()
+          const successNotification = new window.Notification('设置结果', {
+            body: '设置成功'
+          })
+          successNotification.onclick = () => {
+            return true
+          }
+        } else {
+          return false
+        }
+      })
+    }
+  }
+}
+</script>
+<style lang='stylus'>
+.el-message
+  left 60%
+.view-title
+  color #eee
+  font-size 20px
+  text-align center
+  margin 20px auto
+#weibo-view
+  .el-form
+    label  
+      line-height 22px
+      padding-bottom 0
+      color #eee
+    .el-button
+      width 100%
+    .el-input__inner
+      border-radius 19px
+    .el-radio-group
+      margin-left 25px
+</style>

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -26,6 +26,11 @@ export default new Router({
           name: 'weibo'
         },
         {
+          path: 'weibo-cookie',
+          component: require('@/components/SettingView/WeiboCookie').default,
+          name: 'weibo-cookie'
+        },
+        {
           path: 'qiniu',
           component: require('@/components/SettingView/Qiniu').default,
           name: 'qiniu'


### PR DESCRIPTION
由于微博方式屡次需要验证码...顾推荐添加cookie版微博图床上传方式.....

附cookie获取方式:

浏览器手动登录微博,打开 http://weibo.com/minipublish 打开控制台,得到cookie(亲测documen.cookie不行)
![image](https://user-images.githubusercontent.com/10610925/32206240-ffc23b26-bdc1-11e7-8f3f-d31dcc682b5a.png)

关联issue:  #10 
