### PR TITLE
 📝 Docs: add note for windows electron mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ npm run dev # 重新进入开发模式
 
 ```bash
 export ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+# 在 Windows 上，则可以使用 set ELECTRON_MIRROR=https://npm.taobao.org/mirrors/electron/ （无需引号）
 npm run build
 ```
 


### PR DESCRIPTION
Just a small improvement, it seems that I have to set this `ELECTRON_MIRROR` before I run yarn, this is mainly the network issue.

```bash
D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ yarn
yarn install v1.15.2
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
error D:\github\electron-quick-start\node_modules\electron: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: D:\github\electron-quick-start\node_modules\electron
Output:
Downloading tmp-6680-0-electron-v5.0.1-win32-x64.zip
Error: connect ETIMEDOUT 13.229.188.59:443
D:\github\electron-quick-start\node_modules\electron\install.js:49
  throw err
  ^

Error: connect ETIMEDOUT 13.229.188.59:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1117:14)
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ export ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
'export' is not recognized as an internal or external command,
operable program or batch file.

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ export ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
'export' is not recognized as an internal or external command,
operable program or batch file.

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ set ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ yarn
yarn install v1.15.2
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
error D:\github\electron-quick-start\node_modules\electron: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: D:\github\electron-quick-start\node_modules\electron
Output:
Downloading tmp-6180-0-electron-v5.0.1-win32-x64.zip
[>                                            ] 0.0% (0 B/s)
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: Invalid URI "%22https://npm.taobao.org/mirrors/electron/%225.0.1/electron-v5.0.1-win32-x64.zip"
    at Request.init (D:\github\electron-quick-start\node_modules\request\request.js:273:31)
    at new Request (D:\github\electron-quick-start\node_modules\request\request.js:127:8)
    at request (D:\github\electron-quick-start\node_modules\request\index.js:53:10)
    at D:\github\electron-quick-start\node_modules\request\index.js:100:12
    at download (D:\github\electron-quick-start\node_modules\nugget\index.js:164:18)
    at D:\github\electron-quick-start\node_modules\nugget\index.js:133:18
    at FSReqWrap.oncomplete (fs.js:154:21)
Emitted 'error' event at:
    at Request.init (D:\github\electron-quick-start\node_modules\request\request.js:273:17)

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0) 
$ set ELECTRON_MIRROR=https://npm.taobao.org/mirrors/electron/

D:\github\electron-quick-start (master -> origin) (electron-quick-start@1.0.0)
$ yarn
yarn install v1.15.2
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 54.55s.
```