### PR TITLE
fix: 🐛 gallery img object-fit fill -> cover

### DIFF
--- a/src/renderer/pages/Gallery.vue
+++ b/src/renderer/pages/Gallery.vue
@@ -437,7 +437,7 @@ export default {
         transform scale(1.1)
       &-img
         width 100%
-        object-fit fill
+        object-fit cover
     &__tool-panel
       color #ddd
       i


### PR DESCRIPTION
修改gallery中图片的`object-fit`属性
从`fill`改成`cover`