### PR TITLE
:pencil: Docs: update install command by Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Windows 用户请下载最新版本的 `exe` 文件。
 
 macOS 用户请下载最新版本的 `dmg` 文件。
 
-**还可以使用 `brew cask` 来安装 PicGo: `brew cask install picgo`。感谢 @womeimingzi11 的贡献！**
+**还可以使用 [Homebrew](https://brew.sh/) 来安装 PicGo: `brew install picgo --cask`。感谢 @womeimingzi11 的贡献！**
 
 ### Linux
 


### PR DESCRIPTION
Calling `brew cask` install is deprecated!
Update install command by [Homebrew](https://brew.sh/), using `--cask` flag instead of previous `cask`.

Use `cask` flag:
![image](https://user-images.githubusercontent.com/32027253/102240391-c28f0680-3f32-11eb-97a2-82ed531f7fdb.png)

Use `--cask` flag:
![image](https://user-images.githubusercontent.com/32027253/102240208-8f4c7780-3f32-11eb-9276-7d4b41f59044.png)
