### PR TITLE
:bug: Fix: mini window not always on top after reopen

### DIFF
--- a/src/main/events/ipcList.ts
+++ b/src/main/events/ipcList.ts
@@ -134,6 +134,11 @@ export default {
     ipcMain.on('openMiniWindow', () => {
       const miniWindow = windowManager.get(IWindowList.MINI_WINDOW)!
       const settingWindow = windowManager.get(IWindowList.SETTING_WINDOW)!
+
+      if (db.get('settings.miniWindowOntop')) {
+        miniWindow.setAlwaysOnTop(true)
+      }
+
       miniWindow.show()
       miniWindow.focus()
       settingWindow.hide()


### PR DESCRIPTION
在已设置置顶的Mini窗口右键打开主窗口，然后再点右上角按钮返回Mini窗口，发现Mini窗口的置顶失效。
原因是在将Mini窗口隐藏时，Mini窗口的`alwaysOnTop`属性自动变为`false`，通过这种办法可以观察到这一点：
```js
if (windowManager.has(IWindowList.MINI_WINDOW)) {
  windowManager.get(IWindowList.MINI_WINDOW)!.hide()

  console.log(windowManager.get(IWindowList.MINI_WINDOW)!.isAlwaysOnTop())
  setTimeout(() => {
    console.log(windowManager.get(IWindowList.MINI_WINDOW)!.isAlwaysOnTop())
  }, 10000)
}
```
解决办法是在Mini窗口重新打开前再次设置。