### PR TITLE
:sparkles: Feature: add server response headers for CORS

### DIFF
--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -39,13 +39,19 @@ class Server {
   }
 
   private handleRequest = (request: http.IncomingMessage, response: http.ServerResponse) => {
+    if (request.method === 'OPTIONS') {
+      handleResponse({
+        response
+      })
+      return
+    }
+    
     if (request.method === 'POST') {
       if (!routers.getHandler(request.url!)) {
         logger.warn(`[PicGo Server] don't support [${request.url}] url`)
         handleResponse({
           response,
           statusCode: 404,
-          header: {},
           body: {
             success: false
           }

--- a/src/main/server/utils.ts
+++ b/src/main/server/utils.ts
@@ -4,7 +4,10 @@ export const handleResponse = ({
   response,
   statusCode = 200,
   header = {
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'access-control-allow-headers': '*',
+    'access-control-allow-methods': 'POST, GET, OPTIONS',
+    'access-control-allow-origin': '*'
   },
   body = {
     success: false

--- a/src/renderer/pages/Plugin.vue
+++ b/src/renderer/pages/Plugin.vue
@@ -140,7 +140,8 @@ export default class extends Vue {
   pluginNameList: string[] = []
   loading = true
   needReload = false
-  pluginListToolTip = this.$T('PLUGIN_LIST')importLocalPluginToolTip = this.$T('PLUGIN_IMPORT_LOCAL')
+  pluginListToolTip = this.$T('PLUGIN_LIST')
+  importLocalPluginToolTip = this.$T('PLUGIN_IMPORT_LOCAL')
   id = ''
   os = ''
   defaultLogo: string = 'this.src="https://cdn.jsdelivr.net/gh/Molunerfinn/PicGo@dev/public/roundLogo.png"'


### PR DESCRIPTION
I am using PicGo for uploading my image to qiniu in obsidian ( A markdown editor )，but I got a CORS error, as the PicGo server is designed for local upload, It may should allow any of origin. 
this can resolve this case.

what do you think of cors ? should it be an item of config or just set '*' for any origin ?