### PR TITLE
:bug: Fix(plugin): refresh plugin config dialog state

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mime-types": "^3.0.2",
     "mitt": "^3.0.1",
     "multer": "^1.4.5-lts.1",
-    "picgo": "^2.0.2",
+    "picgo": "^2.0.3",
     "qrcode.vue": "^3.3.3",
     "semver": "^7.7.3",
     "shell-path": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
       picgo:
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.0.3
+        version: 2.0.3
       qrcode.vue:
         specifier: ^3.3.3
         version: 3.6.0(vue@3.5.25(typescript@5.9.3))
@@ -1431,8 +1431,8 @@ packages:
     peerDependencies:
       eslint: '>=9.0.0'
 
-  '@sxzz/popperjs-es@2.11.7':
-    resolution: {integrity: sha512-Ccy0NlLkzr0Ex2FKvh2X+OyERHXJ88XJ1MXtsI9y9fGexlaXaVTPzBCRBwIxFkORuOb+uBqeu+RqnpgYTEZRUQ==}
+  '@sxzz/popperjs-es@2.11.8':
+    resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -1938,8 +1938,8 @@ packages:
     resolution: {integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==}
     deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
 
-  axios@1.13.3:
-    resolution: {integrity: sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   babel-polyfill@6.26.0:
     resolution: {integrity: sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==}
@@ -2148,8 +2148,8 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
-  citty@0.2.0:
-    resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
+  citty@0.2.1:
+    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
@@ -2542,8 +2542,8 @@ packages:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
 
-  default-browser@5.4.0:
-    resolution: {integrity: sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==}
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
   default-shell@1.0.1:
@@ -2643,6 +2643,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dpdm@3.14.0:
@@ -2883,6 +2887,10 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -2987,8 +2995,8 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  filelist@1.0.4:
-    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3069,6 +3077,10 @@ packages:
 
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
   fs-extra@6.0.1:
@@ -3297,8 +3309,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.11.6:
-    resolution: {integrity: sha512-ofIiiHyl34SV6AuhE3YT2mhO5HRWokce+eUYE82TsP6z0/H3JeJcjVWEMSIAiw2QkjDOEpES/lYsg8eEbsLtdw==}
+  hono@4.12.3:
+    resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -3618,8 +3630,8 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
-  is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   isarray@1.0.0:
@@ -3820,6 +3832,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
@@ -3970,8 +3985,8 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.5:
@@ -4152,8 +4167,8 @@ packages:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
 
-  nypm@0.6.4:
-    resolution: {integrity: sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==}
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4349,8 +4364,8 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
-  picgo@2.0.2:
-    resolution: {integrity: sha512-zRHpUzTAHvUJtdC6Hxuopi3WgIVEP6CYLAbI0rfUR00tZS+m3UyiJ9vuevy1Wf4acndjqe0kjIqyO2F7ZgJrpQ==}
+  picgo@2.0.3:
+    resolution: {integrity: sha512-FkCIUSeJkmyAWYw+uTsi+18LOMYoVFqZjg8l5d5+2gYnv4gFZ7OlJYCnLfhC4WpvK1Q7JECSc16ZykgXnyW/8A==}
     engines: {node: '>= 20.19.0'}
     hasBin: true
 
@@ -4749,6 +4764,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6365,7 +6385,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.2
+      fs-extra: 11.3.3
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -6511,9 +6531,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hono/node-server@1.19.9(hono@4.11.6)':
+  '@hono/node-server@1.19.9(hono@4.12.3)':
     dependencies:
-      hono: 4.11.6
+      hono: 4.12.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -7195,7 +7215,7 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.3
 
-  '@sxzz/popperjs-es@2.11.7': {}
+  '@sxzz/popperjs-es@2.11.8': {}
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -7834,7 +7854,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  axios@1.13.3:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -8084,7 +8104,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  citty@0.2.0: {}
+  citty@0.2.1: {}
 
   cli-cursor@2.1.0:
     dependencies:
@@ -8519,7 +8539,7 @@ snapshots:
 
   default-browser-id@5.0.1: {}
 
-  default-browser@5.4.0:
+  default-browser@5.5.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
@@ -8628,6 +8648,8 @@ snapshots:
 
   dotenv@17.2.3: {}
 
+  dotenv@17.3.1: {}
+
   dpdm@3.14.0:
     dependencies:
       chalk: 4.1.2
@@ -8716,7 +8738,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -8736,7 +8758,7 @@ snapshots:
       '@ctrl/tinycolor': 3.6.1
       '@element-plus/icons-vue': 2.3.2(vue@3.5.25(typescript@5.9.3))
       '@floating-ui/dom': 1.7.4
-      '@popperjs/core': '@sxzz/popperjs-es@2.11.7'
+      '@popperjs/core': '@sxzz/popperjs-es@2.11.8'
       '@types/lodash': 4.17.21
       '@types/lodash-es': 4.17.12
       '@vueuse/core': 9.13.0(vue@3.5.25(typescript@5.9.3))
@@ -9030,6 +9052,10 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -9140,9 +9166,9 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  filelist@1.0.4:
+  filelist@1.0.6:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -9238,6 +9264,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@11.3.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@6.0.1:
     dependencies:
@@ -9352,7 +9385,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.4
       node-fetch-native: 1.6.7
-      nypm: 0.6.4
+      nypm: 0.6.5
       pathe: 2.0.3
 
   git-raw-commits@1.3.6:
@@ -9519,7 +9552,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.11.6: {}
+  hono@4.12.3: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -9840,7 +9873,7 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
@@ -9865,7 +9898,7 @@ snapshots:
   jake@10.9.4:
     dependencies:
       async: 3.2.6
-      filelist: 1.0.4
+      filelist: 1.0.6
       picocolors: 1.1.1
 
   jiti@1.21.7: {}
@@ -10020,6 +10053,8 @@ snapshots:
   lodash@4.17.11: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.17.23: {}
 
   log-symbols@2.2.0:
     dependencies:
@@ -10186,7 +10221,7 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.6:
+  minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.2
 
@@ -10364,9 +10399,9 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nypm@0.6.4:
+  nypm@0.6.5:
     dependencies:
-      citty: 0.2.0
+      citty: 0.2.1
       pathe: 2.0.3
       tinyexec: 1.0.2
 
@@ -10423,7 +10458,7 @@ snapshots:
 
   open@11.0.0:
     dependencies:
-      default-browser: 5.4.0
+      default-browser: 5.5.0
       define-lazy-prop: 3.0.0
       is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
@@ -10561,24 +10596,24 @@ snapshots:
 
   pend@1.2.0: {}
 
-  picgo@2.0.2:
+  picgo@2.0.3:
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.6)
+      '@hono/node-server': 1.19.9(hono@4.12.3)
       '@picgo/i18n': 1.0.0
       '@picgo/store': 2.1.0
-      axios: 1.13.3
+      axios: 1.13.6
       chalk: 2.4.2
       commander: 8.3.0
       comment-json: 4.5.1
       cross-spawn: 6.0.6
       dayjs: 1.11.19
-      dotenv: 17.2.3
+      dotenv: 17.3.1
       ejs: 3.1.10
       form-data: 4.0.5
       fs-extra: 6.0.1
       giget: 2.0.0
       globby: 11.1.0
-      hono: 4.11.6
+      hono: 4.12.3
       image-size: 0.8.3
       inquirer: 6.5.2
       is-wsl: 2.2.0
@@ -10978,6 +11013,8 @@ snapshots:
   semver@7.7.2: {}
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   serialize-error@7.0.1:
     dependencies:
@@ -11633,8 +11670,8 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      esquery: 1.6.0
-      semver: 7.7.3
+      esquery: 1.7.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11769,7 +11806,7 @@ snapshots:
 
   wsl-utils@0.3.1:
     dependencies:
-      is-wsl: 3.1.0
+      is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
   xml-name-validator@4.0.0: {}

--- a/src/main/events/remotes/menu.ts
+++ b/src/main/events/remotes/menu.ts
@@ -187,6 +187,9 @@ const buildPluginPageMenu = (plugin: IPicGoPlugin) => {
     }
   }]
   for (const i in plugin.config) {
+    if (i === 'uploader') {
+      continue
+    }
     if (plugin.config[i].config.length > 0) {
       const obj = {
         label: T('CONFIG_THING', {

--- a/src/renderer/components/ConfigForm.vue
+++ b/src/renderer/components/ConfigForm.vue
@@ -27,7 +27,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { reactive, ref, watch, toRefs } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { getConfig } from '@/utils/dataSender'
 import { useRoute } from 'vue-router'
 import BaseConfigForm from './form/BaseConfigForm.vue'
@@ -35,7 +35,7 @@ import { useConfigForm } from '@/hooks/useConfigForm'
 import { useStore } from '@/hooks/useStore'
 
 interface IProps {
-  config: any[]
+  config: IPicGoPluginConfig[]
   type: 'uploader' | 'transformer' | 'plugin'
   id: string
   colorMode?: 'white' | 'dark'
@@ -46,7 +46,7 @@ const $route = useRoute()
 const $form = ref<IFormInstance>()
 const configList = ref<IPicGoPluginConfig[]>([])
 const formModel = reactive<IStringKeyMap>({})
-const isUploader = props.type === 'uploader'
+const isUploader = computed(() => props.type === 'uploader')
 const store = useStore()
 
 async function validate (): Promise<IStringKeyMap | false> {
@@ -72,9 +72,16 @@ function getConfigType () {
 
 const handleConfigForm = useConfigForm()
 
+function resetFormModel () {
+  Object.keys(formModel).forEach((key) => {
+    delete formModel[key]
+  })
+}
+
 async function handleConfig (inputConfig: IPicGoPluginConfig[]) {
   const currentConfig = await getCurConfigFormData()
-  const resetConfig = isUploader && !$route.params.configId
+  const resetConfig = isUploader.value && !$route.params.configId
+  resetFormModel()
   Object.assign(formModel, currentConfig)
   configList.value = handleConfigForm(inputConfig, formModel, currentConfig, resetConfig)
 }
@@ -82,7 +89,7 @@ async function handleConfig (inputConfig: IPicGoPluginConfig[]) {
 async function getCurConfigFormData () {
   const configId = $route.params.configId
   const configType = getConfigType()
-  if (isUploader) {
+  if (isUploader.value) {
     const cachedList = store?.state.appConfig?.uploader?.[props.id]?.configList
     const curTypeConfigList = Array.isArray(cachedList)
       ? cachedList
@@ -99,8 +106,8 @@ async function resetConfig () {
   Object.assign(formModel, config)
 }
 
-watch(toRefs(props.config), (val: IPicGoPluginConfig[]) => {
-  handleConfig(val)
+watch(() => props.config, async (val: IPicGoPluginConfig[]) => {
+  await handleConfig(val)
 }, {
   deep: true,
   immediate: true

--- a/src/renderer/pages/Plugin.vue
+++ b/src/renderer/pages/Plugin.vue
@@ -170,6 +170,7 @@
     >
       <config-form
         :id="configName"
+        :key="configFormKey"
         ref="$configForm"
         :config="config"
         :type="currentType"
@@ -222,13 +223,14 @@ import { IRPCActionType } from '~/universal/types/enum'
 const $confirm = ElMessageBox.confirm
 const searchText = ref('')
 const pluginList = ref<IPicGoPlugin[]>([])
-const config = ref<any[]>([])
+const config = ref<IPicGoPluginConfig[]>([])
 const currentType = ref<'plugin' | 'uploader' | 'transformer'>('plugin')
 const configName = ref('')
 const dialogVisible = ref(false)
 const pluginNameList = ref<string[]>([])
 const loading = ref(true)
 const needReload = ref(false)
+const configFormKey = computed(() => `${currentType.value}:${configName.value}`)
 const pluginListToolTip = $T('PLUGIN_LIST')
 const importLocalPluginToolTip = $T('PLUGIN_IMPORT_LOCAL')
 // const id = ref('')
@@ -320,11 +322,11 @@ onBeforeMount(async () => {
     })
     pluginNameList.value = pluginNameList.value.filter(item => item !== plugin)
   })
-  ipcRenderer.on(PICGO_CONFIG_PLUGIN, (evt: IpcRendererEvent, _currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: any) => {
+  ipcRenderer.on(PICGO_CONFIG_PLUGIN, (evt: IpcRendererEvent, _currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: IPicGoPluginConfig[]) => {
     currentType.value = _currentType
     configName.value = _configName
-    dialogVisible.value = true
     config.value = _config
+    dialogVisible.value = true
   })
   ipcRenderer.on(PICGO_HANDLE_PLUGIN_ING, (evt: IpcRendererEvent, fullName: string) => {
     pluginList.value.forEach(item => {

--- a/src/renderer/pages/Plugin.vue
+++ b/src/renderer/pages/Plugin.vue
@@ -199,10 +199,7 @@ import { Close, Download, Goods, Remove, Setting } from '@element-plus/icons-vue
 import { T as $T } from '@/i18n/index'
 import ConfigForm from '@/components/ConfigForm.vue'
 import { debounce, DebouncedFunc } from 'lodash'
-import {
-  ipcRenderer,
-  IpcRendererEvent
-} from 'electron'
+import type { IpcRendererEvent } from 'electron'
 import { handleStreamlinePluginName } from '~/universal/utils/common'
 import {
   OPEN_URL,
@@ -213,13 +210,14 @@ import {
   GET_PICBEDS,
   PICGO_HANDLE_PLUGIN_DONE
 } from '#/events/constants'
-import { computed, ref, onBeforeMount, onBeforeUnmount, watch } from 'vue'
+import { computed, ref, onBeforeMount, watch } from 'vue'
 import { getConfig, saveConfig, sendRPC, sendToMain } from '@/utils/dataSender'
 import { showNotification } from '@/utils/notification'
 import { ElMessageBox } from 'element-plus'
 import axios from 'axios'
 import { getRendererStaticFileUrl } from '@/utils/static'
 import { IRPCActionType } from '~/universal/types/enum'
+import { useIPCOn } from '@/hooks/useIPC'
 const $confirm = ElMessageBox.confirm
 const searchText = ref('')
 const pluginList = ref<IPicGoPlugin[]>([])
@@ -265,85 +263,94 @@ watch(dialogVisible, (val: boolean) => {
   }
 })
 
-onBeforeMount(async () => {
-  ipcRenderer.on('hideLoading', () => {
-    loading.value = false
-  })
-  ipcRenderer.on(PICGO_HANDLE_PLUGIN_DONE, (evt: IpcRendererEvent, fullName: string) => {
-    pluginList.value.forEach(item => {
-      if (item.fullName === fullName || (item.name === fullName)) {
-        item.ing = false
-      }
-    })
-    loading.value = false
-  })
-  ipcRenderer.on('pluginList', (evt: IpcRendererEvent, list: IPicGoPlugin[]) => {
-    pluginList.value = list
-    pluginNameList.value = list.map(item => item.fullName)
-    loading.value = false
-  })
-  ipcRenderer.on('installPlugin', (evt: IpcRendererEvent, { success, body }: {
-    success: boolean,
-    body: string
-  }) => {
-    loading.value = false
-    pluginList.value.forEach(item => {
-      if (item.fullName === body) {
-        item.ing = false
-        item.hasInstall = success
-      }
-    })
-  })
-  ipcRenderer.on('updateSuccess', (evt: IpcRendererEvent, plugin: string) => {
-    loading.value = false
-    pluginList.value.forEach(item => {
-      if (item.fullName === plugin) {
-        item.ing = false
-        item.hasInstall = true
-      }
-      getPicBeds()
-    })
-    handleReload()
-    getPluginList()
-  })
-  ipcRenderer.on('uninstallSuccess', (evt: IpcRendererEvent, plugin: string) => {
-    loading.value = false
-    pluginList.value = pluginList.value.filter(item => {
-      if (item.fullName === plugin) { // restore Uploader & Transformer after uninstalling
-        if (item.config.transformer.name) {
-          handleRestoreState('transformer', item.config.transformer.name)
-        }
-        if (item.config.uploader.name) {
-          handleRestoreState('uploader', item.config.uploader.name)
-        }
-        getPicBeds()
-      }
-      return item.fullName !== plugin
-    })
-    pluginNameList.value = pluginNameList.value.filter(item => item !== plugin)
-  })
-  ipcRenderer.on(PICGO_CONFIG_PLUGIN, (evt: IpcRendererEvent, _currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: IPicGoPluginConfig[]) => {
-    currentType.value = _currentType
-    configName.value = _configName
-    config.value = _config
-    dialogVisible.value = true
-  })
-  ipcRenderer.on(PICGO_HANDLE_PLUGIN_ING, (evt: IpcRendererEvent, fullName: string) => {
-    pluginList.value.forEach(item => {
-      if (item.fullName === fullName || (item.name === fullName)) {
-        item.ing = true
-      }
-    })
-    loading.value = true
-  })
-  ipcRenderer.on(PICGO_TOGGLE_PLUGIN, (evt: IpcRendererEvent, fullName: string, enabled: boolean) => {
-    const plugin = pluginList.value.find(item => item.fullName === fullName)
-    if (plugin) {
-      plugin.enabled = enabled
-      getPicBeds()
-      needReload.value = true
+useIPCOn('hideLoading', () => {
+  loading.value = false
+})
+
+useIPCOn(PICGO_HANDLE_PLUGIN_DONE, (evt: IpcRendererEvent, fullName: string) => {
+  pluginList.value.forEach(item => {
+    if (item.fullName === fullName || (item.name === fullName)) {
+      item.ing = false
     }
   })
+  loading.value = false
+})
+
+useIPCOn('pluginList', (evt: IpcRendererEvent, list: IPicGoPlugin[]) => {
+  pluginList.value = list
+  pluginNameList.value = list.map(item => item.fullName)
+  loading.value = false
+})
+
+useIPCOn('installPlugin', (evt: IpcRendererEvent, { success, body }: {
+  success: boolean,
+  body: string
+}) => {
+  loading.value = false
+  pluginList.value.forEach(item => {
+    if (item.fullName === body) {
+      item.ing = false
+      item.hasInstall = success
+    }
+  })
+})
+
+useIPCOn('updateSuccess', (evt: IpcRendererEvent, plugin: string) => {
+  loading.value = false
+  pluginList.value.forEach(item => {
+    if (item.fullName === plugin) {
+      item.ing = false
+      item.hasInstall = true
+    }
+    getPicBeds()
+  })
+  handleReload()
+  getPluginList()
+})
+
+useIPCOn('uninstallSuccess', (evt: IpcRendererEvent, plugin: string) => {
+  loading.value = false
+  pluginList.value = pluginList.value.filter(item => {
+    if (item.fullName === plugin) { // restore Uploader & Transformer after uninstalling
+      if (item.config.transformer.name) {
+        handleRestoreState('transformer', item.config.transformer.name)
+      }
+      if (item.config.uploader.name) {
+        handleRestoreState('uploader', item.config.uploader.name)
+      }
+      getPicBeds()
+    }
+    return item.fullName !== plugin
+  })
+  pluginNameList.value = pluginNameList.value.filter(item => item !== plugin)
+})
+
+useIPCOn(PICGO_CONFIG_PLUGIN, (evt: IpcRendererEvent, _currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: IPicGoPluginConfig[]) => {
+  currentType.value = _currentType
+  configName.value = _configName
+  config.value = _config
+  dialogVisible.value = true
+})
+
+useIPCOn(PICGO_HANDLE_PLUGIN_ING, (evt: IpcRendererEvent, fullName: string) => {
+  pluginList.value.forEach(item => {
+    if (item.fullName === fullName || (item.name === fullName)) {
+      item.ing = true
+    }
+  })
+  loading.value = true
+})
+
+useIPCOn(PICGO_TOGGLE_PLUGIN, (evt: IpcRendererEvent, fullName: string, enabled: boolean) => {
+  const plugin = pluginList.value.find(item => item.fullName === fullName)
+  if (plugin) {
+    plugin.enabled = enabled
+    getPicBeds()
+    needReload.value = true
+  }
+})
+
+onBeforeMount(async () => {
   getPluginList()
   getSearchResult = debounce(_getSearchResult, 50)
   needReload.value = await getConfig<boolean>('needReload') || false
@@ -537,15 +544,6 @@ function handleImportLocalPlugin () {
   sendToMain('importLocalPlugin')
   loading.value = true
 }
-
-onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners('pluginList')
-  ipcRenderer.removeAllListeners('installPlugin')
-  ipcRenderer.removeAllListeners('uninstallSuccess')
-  ipcRenderer.removeAllListeners('updateSuccess')
-  ipcRenderer.removeAllListeners('hideLoading')
-  ipcRenderer.removeAllListeners(PICGO_HANDLE_PLUGIN_DONE)
-})
 
 </script>
 <script lang="ts">


### PR DESCRIPTION
## What changed
- fix plugin settings dialog stale data when opening config menus across multiple plugins
- hide `uploader` config entry from plugin page context menu (uploader config stays centralized in PicBed settings)
- bump `picgo` dependency from `^2.0.2` to `^2.0.3` and update lockfile

## Validation
- `pnpm check`
- `pnpm test` (triggered by git push hook)

## Related issue
- related to #1394 (plugin settings menu/dialog behavior)
