### PR TITLE
:bug: Fix(gui): migrate renderer electron access to preload bridge

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import vue from '@vitejs/plugin-vue'
-// temp for webUtils
-import electronRenderer from '@molunerfinn/vite-plugin-electron-renderer'
 import { resolve } from 'path'
 
 const alias = {
@@ -27,7 +25,9 @@ export default defineConfig({
     }
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({
+      exclude: ['@picgo/i18n']
+    })],
     resolve: { alias },
     build: {
       outDir: 'dist_electron/preload',
@@ -42,7 +42,7 @@ export default defineConfig({
     root: 'src/renderer',
     publicDir: resolve(__dirname, 'src/renderer/public'),
     resolve: { alias },
-    plugins: [vue(), electronRenderer()],
+    plugins: [vue()],
     build: {
       outDir: 'dist_electron/renderer',
       rollupOptions: {

--- a/src/__tests__/renderer/utils/bridge.spec.ts
+++ b/src/__tests__/renderer/utils/bridge.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type CleanupFn = ReturnType<typeof vi.fn>
+
+describe('renderer/utils/bridge', () => {
+  const onCleanupFns: CleanupFn[] = []
+  const onceCleanupFns: CleanupFn[] = []
+  const onceWrappedListeners: BridgeIpcListener[] = []
+
+  const bridgeApiMock = {
+    ipc: {
+      invoke: vi.fn(),
+      send: vi.fn(),
+      off: vi.fn(),
+      removeAllListeners: vi.fn(),
+      on: vi.fn((_channel: string, _listener: BridgeIpcListener) => {
+        const cleanup = vi.fn()
+        onCleanupFns.push(cleanup)
+        return cleanup
+      }),
+      once: vi.fn((channel: string, listener: BridgeIpcListener) => {
+        onceWrappedListeners.push(listener)
+        const cleanup = vi.fn()
+        onceCleanupFns.push(cleanup)
+        return cleanup
+      })
+    },
+    clipboard: {
+      writeText: vi.fn()
+    },
+    webUtils: {
+      getPathForFile: vi.fn()
+    },
+    webFrame: {
+      setVisualZoomLevelLimits: vi.fn()
+    },
+    env: {
+      platform: 'darwin' as NodeJS.Platform,
+      isDev: false
+    },
+    i18n: {
+      ObjectAdapter: {
+        create: vi.fn()
+      },
+      I18n: {
+        createFromLocales: vi.fn()
+      }
+    }
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    onCleanupFns.length = 0
+    onceCleanupFns.length = 0
+    onceWrappedListeners.length = 0
+    vi.stubGlobal('window', { bridgeApi: bridgeApiMock })
+    vi.stubGlobal('bridgeApi', bridgeApiMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('cleans up all tracked listeners for off', async () => {
+    const { ipc } = await import('@/utils/bridge')
+    const listener = vi.fn()
+
+    ipc.on('demo', listener)
+    ipc.on('demo', listener)
+    ipc.off('demo', listener)
+
+    expect(bridgeApiMock.ipc.on).toHaveBeenCalledTimes(2)
+    expect(onCleanupFns).toHaveLength(2)
+    expect(onCleanupFns[0]).toHaveBeenCalledTimes(1)
+    expect(onCleanupFns[1]).toHaveBeenCalledTimes(1)
+  })
+
+  it('untracks once listeners after invocation so off no longer cleans them up', async () => {
+    const { ipc } = await import('@/utils/bridge')
+    const listener = vi.fn()
+
+    ipc.once('demo', listener)
+
+    expect(bridgeApiMock.ipc.once).toHaveBeenCalledTimes(1)
+    expect(onceWrappedListeners).toHaveLength(1)
+
+    onceWrappedListeners[0]('payload')
+    ipc.off('demo', listener)
+
+    expect(listener).toHaveBeenCalledWith('payload')
+    expect(onceCleanupFns[0]).not.toHaveBeenCalled()
+  })
+
+  it('clears local listener tracking after removeAllListeners', async () => {
+    const { ipc } = await import('@/utils/bridge')
+    const listener = vi.fn()
+
+    ipc.on('demo', listener)
+    ipc.on('demo', listener)
+    ipc.removeAllListeners('demo')
+    ipc.off('demo', listener)
+
+    expect(bridgeApiMock.ipc.removeAllListeners).toHaveBeenCalledWith('demo')
+    expect(onCleanupFns[0]).not.toHaveBeenCalled()
+    expect(onCleanupFns[1]).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/renderer/utils/bridge.spec.ts
+++ b/src/__tests__/renderer/utils/bridge.spec.ts
@@ -3,26 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 type CleanupFn = ReturnType<typeof vi.fn>
 
 describe('renderer/utils/bridge', () => {
-  const onCleanupFns: CleanupFn[] = []
-  const onceCleanupFns: CleanupFn[] = []
-  const onceWrappedListeners: BridgeIpcListener[] = []
+  let onCleanup: CleanupFn
+  let onceCleanup: CleanupFn
 
   const bridgeApiMock = {
     ipc: {
       invoke: vi.fn(),
       send: vi.fn(),
-      off: vi.fn(),
       removeAllListeners: vi.fn(),
       on: vi.fn((_channel: string, _listener: BridgeIpcListener) => {
-        const cleanup = vi.fn()
-        onCleanupFns.push(cleanup)
-        return cleanup
+        onCleanup = vi.fn()
+        return onCleanup
       }),
-      once: vi.fn((channel: string, listener: BridgeIpcListener) => {
-        onceWrappedListeners.push(listener)
-        const cleanup = vi.fn()
-        onceCleanupFns.push(cleanup)
-        return cleanup
+      once: vi.fn((_channel: string, _listener: BridgeIpcListener) => {
+        onceCleanup = vi.fn()
+        return onceCleanup
       })
     },
     clipboard: {
@@ -51,9 +46,8 @@ describe('renderer/utils/bridge', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    onCleanupFns.length = 0
-    onceCleanupFns.length = 0
-    onceWrappedListeners.length = 0
+    onCleanup = vi.fn()
+    onceCleanup = vi.fn()
     vi.stubGlobal('window', { bridgeApi: bridgeApiMock })
     vi.stubGlobal('bridgeApi', bridgeApiMock)
   })
@@ -62,47 +56,33 @@ describe('renderer/utils/bridge', () => {
     vi.unstubAllGlobals()
   })
 
-  it('cleans up all tracked listeners for off', async () => {
+  it('returns preload cleanup for on', async () => {
     const { ipc } = await import('@/utils/bridge')
     const listener = vi.fn()
 
-    ipc.on('demo', listener)
-    ipc.on('demo', listener)
-    ipc.off('demo', listener)
+    const cleanup = ipc.on('demo', listener)
+    cleanup()
 
-    expect(bridgeApiMock.ipc.on).toHaveBeenCalledTimes(2)
-    expect(onCleanupFns).toHaveLength(2)
-    expect(onCleanupFns[0]).toHaveBeenCalledTimes(1)
-    expect(onCleanupFns[1]).toHaveBeenCalledTimes(1)
+    expect(bridgeApiMock.ipc.on).toHaveBeenCalledWith('demo', listener)
+    expect(onCleanup).toHaveBeenCalledTimes(1)
   })
 
-  it('untracks once listeners after invocation so off no longer cleans them up', async () => {
+  it('returns preload cleanup for once', async () => {
     const { ipc } = await import('@/utils/bridge')
     const listener = vi.fn()
 
-    ipc.once('demo', listener)
+    const cleanup = ipc.once('demo', listener)
+    cleanup()
 
     expect(bridgeApiMock.ipc.once).toHaveBeenCalledTimes(1)
-    expect(onceWrappedListeners).toHaveLength(1)
-
-    onceWrappedListeners[0]('payload')
-    ipc.off('demo', listener)
-
-    expect(listener).toHaveBeenCalledWith('payload')
-    expect(onceCleanupFns[0]).not.toHaveBeenCalled()
+    expect(bridgeApiMock.ipc.once).toHaveBeenCalledWith('demo', listener)
+    expect(onceCleanup).toHaveBeenCalledTimes(1)
   })
 
-  it('clears local listener tracking after removeAllListeners', async () => {
+  it('delegates removeAllListeners to preload', async () => {
     const { ipc } = await import('@/utils/bridge')
-    const listener = vi.fn()
-
-    ipc.on('demo', listener)
-    ipc.on('demo', listener)
     ipc.removeAllListeners('demo')
-    ipc.off('demo', listener)
 
     expect(bridgeApiMock.ipc.removeAllListeners).toHaveBeenCalledWith('demo')
-    expect(onCleanupFns[0]).not.toHaveBeenCalled()
-    expect(onCleanupFns[1]).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/renderer/utils/dataSender.spec.ts
+++ b/src/__tests__/renderer/utils/dataSender.spec.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { saveConfig } from '@/utils/dataSender'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PICGO_SAVE_CONFIG } from '#/events/constants'
 
 describe('renderer/utils/dataSender', () => {
@@ -36,12 +35,20 @@ describe('renderer/utils/dataSender', () => {
   }
 
   beforeEach(() => {
+    vi.resetModules()
     vi.clearAllMocks()
     vi.stubGlobal('window', { bridgeApi: bridgeApiMock })
+    vi.stubGlobal('bridgeApi', bridgeApiMock)
     bridgeApiMock.ipc.invoke.mockResolvedValue(true)
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('invokes save config IPC after saveConfig', async () => {
+    const { saveConfig } = await import('@/utils/dataSender')
+
     await saveConfig('settings.language', 'en')
 
     expect(bridgeApiMock.ipc.invoke).toHaveBeenCalledWith(PICGO_SAVE_CONFIG, {

--- a/src/__tests__/renderer/utils/dataSender.spec.ts
+++ b/src/__tests__/renderer/utils/dataSender.spec.ts
@@ -8,7 +8,6 @@ describe('renderer/utils/dataSender', () => {
       on: vi.fn(),
       once: vi.fn(),
       send: vi.fn(),
-      off: vi.fn(),
       removeAllListeners: vi.fn()
     },
     clipboard: {

--- a/src/__tests__/renderer/utils/dataSender.spec.ts
+++ b/src/__tests__/renderer/utils/dataSender.spec.ts
@@ -1,32 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { saveConfig } from '@/utils/dataSender'
 import { PICGO_SAVE_CONFIG } from '#/events/constants'
-import { ipcRenderer } from 'electron'
 
-vi.mock('electron', () => {
-  return {
-    ipcRenderer: {
+describe('renderer/utils/dataSender', () => {
+  const bridgeApiMock = {
+    ipc: {
       invoke: vi.fn(),
       on: vi.fn(),
       once: vi.fn(),
       send: vi.fn(),
-      removeListener: vi.fn()
+      off: vi.fn(),
+      removeAllListeners: vi.fn()
+    },
+    clipboard: {
+      writeText: vi.fn()
+    },
+    webUtils: {
+      getPathForFile: vi.fn()
+    },
+    webFrame: {
+      setVisualZoomLevelLimits: vi.fn()
+    },
+    env: {
+      platform: 'darwin' as NodeJS.Platform,
+      isDev: false
+    },
+    i18n: {
+      ObjectAdapter: {
+        create: vi.fn()
+      },
+      I18n: {
+        createFromLocales: vi.fn()
+      }
     }
   }
-})
-
-describe('renderer/utils/dataSender', () => {
-  const ipcRendererMock = vi.mocked(ipcRenderer)
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ipcRendererMock.invoke.mockResolvedValue(true)
+    vi.stubGlobal('window', { bridgeApi: bridgeApiMock })
+    bridgeApiMock.ipc.invoke.mockResolvedValue(true)
   })
 
   it('invokes save config IPC after saveConfig', async () => {
     await saveConfig('settings.language', 'en')
 
-    expect(ipcRendererMock.invoke).toHaveBeenCalledWith(PICGO_SAVE_CONFIG, {
+    expect(bridgeApiMock.ipc.invoke).toHaveBeenCalledWith(PICGO_SAVE_CONFIG, {
       'settings.language': 'en'
     })
   })

--- a/src/main/apis/app/window/windowList.ts
+++ b/src/main/apis/app/window/windowList.ts
@@ -1,4 +1,4 @@
-// import path from 'path'
+import path from 'path'
 import {
   SETTING_WINDOW_URL,
   TRAY_WINDOW_URL,
@@ -20,10 +20,10 @@ import picgo from '@core/picgo'
 const windowList = new Map<IWindowList, IWindowListItem>()
 
 const defaultWebPreferences = {
-  // preload: path.join(__dirname, '../preload/index.js'),
-  nodeIntegration: true,
-  contextIsolation: false,
-  nodeIntegrationInWorker: true,
+  preload: path.join(__dirname, '../preload/index.js'),
+  nodeIntegration: false,
+  contextIsolation: true,
+  nodeIntegrationInWorker: false,
   backgroundThrottling: false
 }
 
@@ -109,6 +109,9 @@ windowList.set(IWindowList.SETTING_WINDOW, {
     return options
   },
   callback (window, windowManager) {
+    window.webContents.openDevTools({
+      mode: 'detach'
+    })
     window.loadURL(handleWindowParams(SETTING_WINDOW_URL))
     window.on('closed', () => {
       bus.emit(TOGGLE_SHORTKEY_MODIFIED_MODE, false)

--- a/src/main/apis/app/window/windowList.ts
+++ b/src/main/apis/app/window/windowList.ts
@@ -109,9 +109,6 @@ windowList.set(IWindowList.SETTING_WINDOW, {
     return options
   },
   callback (window, windowManager) {
-    window.webContents.openDevTools({
-      mode: 'detach'
-    })
     window.loadURL(handleWindowParams(SETTING_WINDOW_URL))
     window.on('closed', () => {
       bus.emit(TOGGLE_SHORTKEY_MODIFIED_MODE, false)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,45 +11,9 @@ import { ObjectAdapter } from '@picgo/i18n/dist/adapters/object'
 type PreloadIpcListener = (...args: unknown[]) => void
 type ElectronIpcListener = (_event: Electron.IpcRendererEvent, ...args: unknown[]) => void
 
-const listenerMap = new Map<string, Map<PreloadIpcListener, Set<ElectronIpcListener>>>()
-
-const getChannelListeners = (channel: string) => {
-  let channelListeners = listenerMap.get(channel)
-  if (!channelListeners) {
-    channelListeners = new Map()
-    listenerMap.set(channel, channelListeners)
-  }
-  return channelListeners
-}
-
-const trackListener = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
-  const channelListeners = getChannelListeners(channel)
-  const listenerSet = channelListeners.get(listener) || new Set<ElectronIpcListener>()
-  listenerSet.add(wrappedListener)
-  channelListeners.set(listener, listenerSet)
-}
-
-const untrackListener = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
-  const channelListeners = listenerMap.get(channel)
-  if (!channelListeners) return
-
-  const listenerSet = channelListeners.get(listener)
-  if (!listenerSet) return
-
-  listenerSet.delete(wrappedListener)
-  if (listenerSet.size === 0) {
-    channelListeners.delete(listener)
-  }
-
-  if (channelListeners.size === 0) {
-    listenerMap.delete(channel)
-  }
-}
-
-const createCleanup = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
+const createCleanup = (channel: string, wrappedListener: ElectronIpcListener) => {
   return () => {
     ipcRenderer.removeListener(channel, wrappedListener)
-    untrackListener(channel, listener, wrappedListener)
   }
 }
 
@@ -63,41 +27,21 @@ const ipc = {
       listener(...args)
     }
 
-    trackListener(channel, listener, wrappedListener)
     ipcRenderer.on(channel, wrappedListener)
 
-    return createCleanup(channel, listener, wrappedListener)
+    return createCleanup(channel, wrappedListener)
   },
   once: (channel: string, listener: PreloadIpcListener) => {
     const wrappedListener: ElectronIpcListener = (_event, ...args) => {
-      try {
-        listener(...args)
-      } finally {
-        untrackListener(channel, listener, wrappedListener)
-      }
+      listener(...args)
     }
 
-    trackListener(channel, listener, wrappedListener)
     ipcRenderer.once(channel, wrappedListener)
 
-    return createCleanup(channel, listener, wrappedListener)
-  },
-  off: (channel: string, listener: PreloadIpcListener) => {
-    const listenerSet = listenerMap.get(channel)?.get(listener)
-    if (!listenerSet) return
-
-    listenerSet.forEach((wrappedListener) => {
-      ipcRenderer.removeListener(channel, wrappedListener)
-    })
-
-    listenerMap.get(channel)?.delete(listener)
-    if (listenerMap.get(channel)?.size === 0) {
-      listenerMap.delete(channel)
-    }
+    return createCleanup(channel, wrappedListener)
   },
   removeAllListeners: (channel: string) => {
     ipcRenderer.removeAllListeners(channel)
-    listenerMap.delete(channel)
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,8 +70,11 @@ const ipc = {
   },
   once: (channel: string, listener: PreloadIpcListener) => {
     const wrappedListener: ElectronIpcListener = (_event, ...args) => {
-      listener(...args)
-      untrackListener(channel, listener, wrappedListener)
+      try {
+        listener(...args)
+      } finally {
+        untrackListener(channel, listener, wrappedListener)
+      }
     }
 
     trackListener(channel, listener, wrappedListener)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,13 +1,158 @@
-// temp no used
-// will be refactor in future
-import { contextBridge, webUtils } from 'electron'
+import {
+  clipboard,
+  contextBridge,
+  ipcRenderer,
+  webFrame,
+  webUtils
+} from 'electron'
+import { I18n } from '@picgo/i18n/dist/i18n'
+import { ObjectAdapter } from '@picgo/i18n/dist/adapters/object'
 
-const getFilePath = (file: File): string => webUtils.getPathForFile(file)
+type PreloadIpcListener = (...args: unknown[]) => void
+type ElectronIpcListener = (_event: Electron.IpcRendererEvent, ...args: unknown[]) => void
 
-const electronApi = {
-  getFilePath
+const listenerMap = new Map<string, Map<PreloadIpcListener, Set<ElectronIpcListener>>>()
+
+const getChannelListeners = (channel: string) => {
+  let channelListeners = listenerMap.get(channel)
+  if (!channelListeners) {
+    channelListeners = new Map()
+    listenerMap.set(channel, channelListeners)
+  }
+  return channelListeners
 }
 
-contextBridge.exposeInMainWorld('electronApi', electronApi)
+const trackListener = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
+  const channelListeners = getChannelListeners(channel)
+  const listenerSet = channelListeners.get(listener) || new Set<ElectronIpcListener>()
+  listenerSet.add(wrappedListener)
+  channelListeners.set(listener, listenerSet)
+}
 
-export type ElectronApi = typeof electronApi
+const untrackListener = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
+  const channelListeners = listenerMap.get(channel)
+  if (!channelListeners) return
+
+  const listenerSet = channelListeners.get(listener)
+  if (!listenerSet) return
+
+  listenerSet.delete(wrappedListener)
+  if (listenerSet.size === 0) {
+    channelListeners.delete(listener)
+  }
+
+  if (channelListeners.size === 0) {
+    listenerMap.delete(channel)
+  }
+}
+
+const createCleanup = (channel: string, listener: PreloadIpcListener, wrappedListener: ElectronIpcListener) => {
+  return () => {
+    ipcRenderer.removeListener(channel, wrappedListener)
+    untrackListener(channel, listener, wrappedListener)
+  }
+}
+
+const ipc = {
+  send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),
+  invoke: <T>(channel: string, ...args: unknown[]) => {
+    return ipcRenderer.invoke(channel, ...args) as Promise<T>
+  },
+  on: (channel: string, listener: PreloadIpcListener) => {
+    const wrappedListener: ElectronIpcListener = (_event, ...args) => {
+      listener(...args)
+    }
+
+    trackListener(channel, listener, wrappedListener)
+    ipcRenderer.on(channel, wrappedListener)
+
+    return createCleanup(channel, listener, wrappedListener)
+  },
+  once: (channel: string, listener: PreloadIpcListener) => {
+    const wrappedListener: ElectronIpcListener = (_event, ...args) => {
+      listener(...args)
+      untrackListener(channel, listener, wrappedListener)
+    }
+
+    trackListener(channel, listener, wrappedListener)
+    ipcRenderer.once(channel, wrappedListener)
+
+    return createCleanup(channel, listener, wrappedListener)
+  },
+  off: (channel: string, listener: PreloadIpcListener) => {
+    const listenerSet = listenerMap.get(channel)?.get(listener)
+    if (!listenerSet) return
+
+    listenerSet.forEach((wrappedListener) => {
+      ipcRenderer.removeListener(channel, wrappedListener)
+    })
+
+    listenerMap.get(channel)?.delete(listener)
+    if (listenerMap.get(channel)?.size === 0) {
+      listenerMap.delete(channel)
+    }
+  },
+  removeAllListeners: (channel: string) => {
+    ipcRenderer.removeAllListeners(channel)
+    listenerMap.delete(channel)
+  }
+}
+
+type I18nLocalesMap = Record<string, ILocales>
+
+const createObjectAdapterBridge = (locales: I18nLocalesMap) => {
+  const adapter = new ObjectAdapter(locales)
+
+  return {
+    getLocale: (language: string) => adapter.getLocale(language) as ILocales | undefined,
+    setLocales: (nextLocales: I18nLocalesMap) => adapter.setLocales(nextLocales),
+    setLocale: (language: string, locale: ILocales) => adapter.setLocale(language, locale)
+  }
+}
+
+const createI18nBridge = (locales: I18nLocalesMap, defaultLanguage: string) => {
+  const i18n = new I18n({
+    adapter: new ObjectAdapter(locales),
+    defaultLanguage
+  })
+
+  return {
+    getLanguage: () => i18n.getLanguage(),
+    setLanguage: (language: string) => i18n.setLanguage(language),
+    setDefaultLanguage: (language: string) => i18n.setDefaultLanguage(language),
+    translate: (key: ILocalesKey, args: IStringKeyMap = {}) => i18n.translate(key, args) || key
+  }
+}
+
+const bridgeApi = {
+  ipc,
+  clipboard: {
+    writeText: (text: string) => clipboard.writeText(text)
+  },
+  webUtils: {
+    getPathForFile: (file: File): string => webUtils.getPathForFile(file)
+  },
+  webFrame: {
+    setVisualZoomLevelLimits: (minimumLevel: number, maximumLevel: number) => {
+      webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)
+    }
+  },
+  env: {
+    platform: process.platform,
+    isDev: Boolean(process.env.ELECTRON_RENDERER_URL) || process.env.NODE_ENV === 'development'
+  },
+  i18n: {
+    ObjectAdapter: {
+      create: (locales: I18nLocalesMap) => createObjectAdapterBridge(locales)
+    },
+    I18n: {
+      createFromLocales: (locales: I18nLocalesMap, defaultLanguage: string) => {
+        return createI18nBridge(locales, defaultLanguage)
+      }
+    }
+  }
+}
+
+contextBridge.exposeInMainWorld('bridgeApi', bridgeApi)
+
+export type BridgeApi = typeof bridgeApi

--- a/src/renderer/components/dialog/ConfigFormDialog.vue
+++ b/src/renderer/components/dialog/ConfigFormDialog.vue
@@ -37,7 +37,7 @@ const width = ref(500)
 const handleConfigForm = useConfigForm()
 
 const visible = ref(false)
-useIPCOn(IRPCActionType.OPEN_CONFIG_DIALOG, (event, options: IPicGoPluginShowConfigDialogOption) => {
+useIPCOn(IRPCActionType.OPEN_CONFIG_DIALOG, (options: IPicGoPluginShowConfigDialogOption) => {
   visible.value = true
   configList.value = handleConfigForm(options.config, formModel)
   title.value = options.title

--- a/src/renderer/components/dialog/InputBoxDialog.vue
+++ b/src/renderer/components/dialog/InputBoxDialog.vue
@@ -46,7 +46,6 @@
 </template>
 <script lang="ts" setup>
 import { ref, reactive, onBeforeUnmount, onBeforeMount, watch } from 'vue'
-import { ipcRenderer, IpcRendererEvent } from 'electron'
 import {
   SHOW_INPUT_BOX,
   SHOW_INPUT_BOX_RESPONSE
@@ -54,6 +53,7 @@ import {
 import $bus from '@/utils/bus'
 import { sendToMain } from '@/utils/dataSender'
 import { T as $T } from '@/i18n/index'
+import { ipc } from '@/utils/bridge'
 const inputBoxValue = ref('')
 const inputBoxConfirmValue = ref('')
 const confirmError = ref('')
@@ -66,13 +66,14 @@ const inputBoxOptions = reactive({
   hasConfirm: false,
   confirmPlaceholder: ''
 })
+let cleanupShowInputBox = () => {}
 
 onBeforeMount(() => {
-  ipcRenderer.on(SHOW_INPUT_BOX, ipcEventHandler)
+  cleanupShowInputBox = ipc.on(SHOW_INPUT_BOX, ipcEventHandler)
   $bus.on(SHOW_INPUT_BOX, initInputBoxValue)
 })
 
-function ipcEventHandler (evt: IpcRendererEvent, options: IShowInputBoxOption) {
+function ipcEventHandler (options: IShowInputBoxOption) {
   initInputBoxValue(options)
 }
 
@@ -111,7 +112,7 @@ watch([inputBoxValue, inputBoxConfirmValue], () => {
 })
 
 onBeforeUnmount(() => {
-  ipcRenderer.removeListener(SHOW_INPUT_BOX, ipcEventHandler)
+  cleanupShowInputBox()
   $bus.off(SHOW_INPUT_BOX)
 })
 

--- a/src/renderer/hooks/useIPC.ts
+++ b/src/renderer/hooks/useIPC.ts
@@ -1,20 +1,20 @@
-import { ipcRenderer } from 'electron'
 import { onUnmounted } from 'vue'
 import { IRPCActionType } from '~/universal/types/enum'
+import { ipc } from '@/utils/bridge'
 
-export const useIPCOn = (channel: string, listener: IpcRendererListener) => {
-  ipcRenderer.on(channel, listener)
+export const useIPCOn = (channel: string, listener: BridgeIpcListener) => {
+  const cleanup = ipc.on(channel, listener)
 
   onUnmounted(() => {
-    ipcRenderer.removeListener(channel, listener)
+    cleanup()
   })
 }
 
-export const useIPCOnce = (channel: string, listener: IpcRendererListener) => {
-  ipcRenderer.once(channel, listener)
+export const useIPCOnce = (channel: string, listener: BridgeIpcListener) => {
+  const cleanup = ipc.once(channel, listener)
 
   onUnmounted(() => {
-    ipcRenderer.removeListener(channel, listener)
+    cleanup()
   })
 }
 
@@ -23,7 +23,7 @@ export const useIPCOnce = (channel: string, listener: IpcRendererListener) => {
  */
 export const useIPC = () => {
   return {
-    on: (channel: IRPCActionType, listener: IpcRendererListener) => useIPCOn(channel, listener),
-    once: (channel: IRPCActionType, listener: IpcRendererListener) => useIPCOnce(channel, listener)
+    on: (channel: IRPCActionType, listener: BridgeIpcListener) => useIPCOn(channel, listener),
+    once: (channel: IRPCActionType, listener: BridgeIpcListener) => useIPCOnce(channel, listener)
   }
 }

--- a/src/renderer/hooks/useOS.ts
+++ b/src/renderer/hooks/useOS.ts
@@ -1,10 +1,11 @@
 import { onBeforeMount, ref } from 'vue'
+import { getPlatform } from '@/utils/bridge'
 
 export const useOS = () => {
   const os = ref<string>('')
 
   onBeforeMount(() => {
-    os.value = process.platform
+    os.value = getPlatform()
   })
   return os
 }

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -1,42 +1,37 @@
-import { ipcRenderer } from 'electron'
-import { ObjectAdapter, I18n } from '@picgo/i18n'
 import { GET_CURRENT_LANGUAGE, SET_CURRENT_LANGUAGE, FORCE_UPDATE, GET_LANGUAGE_LIST } from '#/events/constants'
 import bus from '@/utils/bus'
 import { builtinI18nList } from '#/i18n'
+import { ipc, picgoI18n } from '@/utils/bridge'
 
 export class I18nManager {
-  private i18n: I18n | null = null
+  private i18n: BridgeI18nInstance | null = null
   private i18nFileList: II18nItem[] = builtinI18nList
 
   private getLanguageList () {
-    ipcRenderer.send(GET_LANGUAGE_LIST)
-    ipcRenderer.once(GET_LANGUAGE_LIST, (event, list: II18nItem[]) => {
+    ipc.send(GET_LANGUAGE_LIST)
+    ipc.once(GET_LANGUAGE_LIST, (list: II18nItem[]) => {
       this.i18nFileList = list
     })
   }
 
   private getCurrentLanguage () {
-    ipcRenderer.send(GET_CURRENT_LANGUAGE)
-    ipcRenderer.once(GET_CURRENT_LANGUAGE, (event, lang: string, locales: ILocales) => {
+    ipc.send(GET_CURRENT_LANGUAGE)
+    ipc.once(GET_CURRENT_LANGUAGE, (lang: string, locales: ILocales) => {
       this.setLocales(lang, locales)
       bus.emit(FORCE_UPDATE)
     })
   }
 
   private setLocales (lang: string, locales: ILocales) {
-    const objectAdapter = new ObjectAdapter({
+    this.i18n = picgoI18n.I18n.createFromLocales({
       [lang]: locales
-    })
-    this.i18n = new I18n({
-      adapter: objectAdapter,
-      defaultLanguage: lang
-    })
+    }, lang)
   }
 
   constructor () {
     this.getCurrentLanguage()
     this.getLanguageList()
-    ipcRenderer.on(SET_CURRENT_LANGUAGE, (event, lang: string, locales: ILocales) => {
+    ipc.on(SET_CURRENT_LANGUAGE, (lang: string, locales: ILocales) => {
       this.setLocales(lang, locales)
       bus.emit(FORCE_UPDATE)
     })
@@ -47,7 +42,7 @@ export class I18nManager {
   }
 
   setCurrentLanguage (lang: string) {
-    ipcRenderer.send(SET_CURRENT_LANGUAGE, lang)
+    ipc.send(SET_CURRENT_LANGUAGE, lang)
   }
 
   get languageList () {

--- a/src/renderer/layouts/Main.vue
+++ b/src/renderer/layouts/Main.vue
@@ -226,10 +226,6 @@ import QrcodeVue from 'qrcode.vue'
 import pick from 'lodash/pick'
 import pkg from 'root/package.json'
 import * as config from '@/router/config'
-import {
-  ipcRenderer,
-  clipboard
-} from 'electron'
 import InputBoxDialog from '@/components/dialog/InputBoxDialog.vue'
 import {
   MINIMIZE_WINDOW,
@@ -239,9 +235,10 @@ import {
   SHOW_MAIN_PAGE_DONATION
 } from '~/universal/events/constants'
 import { getConfig, sendToMain } from '@/utils/dataSender'
+import { clipboard, isDevEnv, ipc } from '@/utils/bridge'
 import { useOS } from '@/hooks/useOS'
 import { useStore } from '@/hooks/useStore'
-const version = ref(process.env.NODE_ENV === 'production' ? pkg.version : 'Dev')
+const version = ref(isDevEnv() ? 'Dev' : pkg.version)
 const routerConfig = reactive(config)
 const defaultActive = ref(routerConfig.UPLOAD_PAGE)
 const visible = ref(false)
@@ -252,16 +249,18 @@ const picBed = computed(() => store?.state.picBeds ?? [])
 const qrcodeVisible = ref(false)
 const picBedConfigString = ref('')
 const choosedPicBedForQRCode: Ref<string[]> = ref([])
+let cleanupShowQRCode = () => {}
+let cleanupShowDonation = () => {}
 
 const keepAlivePages = $router.getRoutes().filter(item => item.meta.keepAlive).map(item => item.name as string)
 
 onBeforeMount(() => {
   store?.refreshPicBeds()
   handleGetPicPeds()
-  ipcRenderer.on(SHOW_MAIN_PAGE_QRCODE, () => {
+  cleanupShowQRCode = ipc.on(SHOW_MAIN_PAGE_QRCODE, () => {
     qrcodeVisible.value = true
   })
-  ipcRenderer.on(SHOW_MAIN_PAGE_DONATION, () => {
+  cleanupShowDonation = ipc.on(SHOW_MAIN_PAGE_DONATION, () => {
     visible.value = true
   })
 })
@@ -340,8 +339,8 @@ onBeforeRouteUpdate(async (to) => {
 })
 
 onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners(SHOW_MAIN_PAGE_QRCODE)
-  ipcRenderer.removeAllListeners(SHOW_MAIN_PAGE_DONATION)
+  cleanupShowQRCode()
+  cleanupShowDonation()
 })
 
 </script>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,6 +1,5 @@
 import './assets/css/tailwind.css'
 import { createApp } from 'vue'
-import { webFrame } from 'electron'
 import App from './App.vue'
 import router from './router'
 import ElementUI from 'element-plus'
@@ -16,6 +15,7 @@ import { getConfig, saveConfig, sendToMain } from '@/utils/dataSender'
 import { store } from '@/store'
 import vue3PhotoPreview from 'vue3-photo-preview'
 import 'vue3-photo-preview/dist/index.css'
+import { webFrame } from '@/utils/bridge'
 import { getRendererStaticFileUrl } from './utils/static'
 
 webFrame.setVisualZoomLevelLimits(1, 1)

--- a/src/renderer/pages/Gallery.vue
+++ b/src/renderer/pages/Gallery.vue
@@ -190,10 +190,6 @@ import type { IResult } from '@picgo/store/dist/types'
 import { PASTE_TEXT } from '#/events/constants'
 import { CheckboxValueType, ElMessageBox } from 'element-plus'
 import { Close, CaretBottom, Document, Edit, Delete, CaretTop } from '@element-plus/icons-vue'
-import {
-  ipcRenderer,
-  clipboard
-} from 'electron'
 import { computed, nextTick, onActivated, onBeforeUnmount, onBeforeMount, reactive, ref, watch } from 'vue'
 import { saveConfig, sendRPC, sendToMain } from '@/utils/dataSender'
 import { onBeforeRouteUpdate } from 'vue-router'
@@ -204,6 +200,7 @@ import { IRPCActionType } from '~/universal/types/enum'
 import { getRawData } from '@/utils/common'
 import { showNotification } from '@/utils/notification'
 import { useStore } from '@/hooks/useStore'
+import { clipboard, ipc } from '@/utils/bridge'
 const images = ref<ImgInfo[]>([])
 const dialogVisible = ref(false)
 const imgInfo = reactive({
@@ -232,6 +229,7 @@ const pasteStyleMap = {
 const store = useStore()
 const picBed = computed(() => store?.state.picBeds ?? [])
 const visiblePicBedList = computed(() => picBed.value.filter(item => item.visible))
+let cleanupUpdateGallery = () => {}
 onBeforeRouteUpdate((to, from) => {
   if (from.name === 'gallery') {
     clearSelectedList()
@@ -242,7 +240,7 @@ onBeforeRouteUpdate((to, from) => {
 })
 
 onBeforeMount(async () => {
-  ipcRenderer.on(IRPCActionType.UPDATE_GALLERY, () => {
+  cleanupUpdateGallery = ipc.on(IRPCActionType.UPDATE_GALLERY, () => {
     nextTick(async () => {
       updateGallery()
     })
@@ -373,7 +371,7 @@ function handleClose () {
 }
 
 async function copy (item: ImgInfo) {
-  const copyLink = await ipcRenderer.invoke(PASTE_TEXT, getRawData(item))
+  const copyLink = await ipc.invoke<string>(PASTE_TEXT, getRawData(item))
   const obj = {
     title: $T('COPY_LINK_SUCCEED'),
     body: copyLink
@@ -504,7 +502,7 @@ async function multiCopy () {
       if (selectedList[key]) {
         const item = await $$db.getById<ImgInfo>(key)
         if (item) {
-          const txt = await ipcRenderer.invoke(PASTE_TEXT, getRawData(item))
+          const txt = await ipc.invoke<string>(PASTE_TEXT, getRawData(item))
           copyString.push(txt)
           selectedList[key] = false
         }
@@ -532,7 +530,7 @@ async function handlePasteStyleChange (val: string) {
 }
 
 onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners('updateGallery')
+  cleanupUpdateGallery()
 })
 
 const applyAppConfig = () => {

--- a/src/renderer/pages/MiniPage.vue
+++ b/src/renderer/pages/MiniPage.vue
@@ -32,10 +32,6 @@
 // import { Component, Vue, Watch } from 'vue-property-decorator'
 import { T as $T } from '@/i18n/index'
 import { showNotification } from '@/utils/notification'
-import {
-  ipcRenderer,
-  IpcRendererEvent
-} from 'electron'
 import { onBeforeUnmount, onBeforeMount, ref, watch } from 'vue'
 import { LOG_INVALID_URL_LINES, SHOW_MINI_PAGE_MENU, SET_MINI_WINDOW_POS } from '~/universal/events/constants'
 import {
@@ -43,6 +39,7 @@ import {
   parseNewlineSeparatedUrls
 } from '~/universal/utils/common'
 import { sendToMain } from '@/utils/dataSender'
+import { ipc } from '@/utils/bridge'
 import { getFilePath } from '@/utils/common'
 import { getRendererStaticFileUrl } from '@/utils/static'
 import { useOS } from '@/hooks/useOS'
@@ -57,9 +54,10 @@ const wY = ref(-1)
 const screenX = ref(-1)
 const screenY = ref(-1)
 const os = useOS()
+let cleanupUploadProgress = () => {}
 
 onBeforeMount(() => {
-  ipcRenderer.on('uploadProgress', (event: IpcRendererEvent, _progress: number) => {
+  cleanupUploadProgress = ipc.on('uploadProgress', (_progress: number) => {
     if (_progress !== -1) {
       showProgress.value = true
       progress.value = _progress
@@ -229,7 +227,7 @@ function openContextMenu () {
 }
 
 onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners('uploadProgress')
+  cleanupUploadProgress()
   window.removeEventListener('mousedown', handleMouseDown, false)
   window.removeEventListener('mousemove', handleMouseMove, false)
   window.removeEventListener('mouseup', handleMouseUp, false)

--- a/src/renderer/pages/PicGoSetting.vue
+++ b/src/renderer/pages/PicGoSetting.vue
@@ -48,7 +48,7 @@ import { ElForm } from 'element-plus'
 import { Reading } from '@element-plus/icons-vue'
 import { IConfig } from 'picgo'
 import { T as $T } from '@/i18n/index'
-import { enforceNumber, isLinux } from '~/universal/utils/common'
+import { enforceNumber } from '~/universal/utils/common'
 import { computed, onBeforeMount, reactive, ref, watch, type DeepReadonly } from 'vue'
 import ButtonAreaSettings from './components/settings/buttonArea/ButtonAreaSettings.vue'
 import SwitchAreaSettings from './components/settings/switchArea/SwitchAreaSettings.vue'
@@ -57,6 +57,7 @@ import SelectAreaSettings from './components/settings/selectArea/SelectAreaSetti
 import { openURL } from '@/utils/common'
 import { IStartupMode } from '#/types/enum'
 import { useStore } from '@/hooks/useStore'
+import { isLinuxPlatform } from '@/utils/bridge'
 
 const form = reactive<ISettingForm>({
   showUpdateTip: false,
@@ -125,7 +126,7 @@ const applyAppConfig = (config: DeepReadonly<IConfig> | null) => {
   form.logFileSizeLimit = enforceNumber(settings.logFileSizeLimit ?? 10) || 10
   form.showDockIcon = settings.showDockIcon === undefined ? true : settings.showDockIcon
   form.showMenubarIcon = settings.showMenubarIcon === undefined ? true : settings.showMenubarIcon
-  form.startupMode = settings.startupMode || (isLinux ? IStartupMode.SHOW_MINI_WINDOW : IStartupMode.HIDE)
+  form.startupMode = settings.startupMode || (isLinuxPlatform() ? IStartupMode.SHOW_MINI_WINDOW : IStartupMode.HIDE)
 }
 
 watch(appConfig, (config) => {

--- a/src/renderer/pages/Plugin.vue
+++ b/src/renderer/pages/Plugin.vue
@@ -199,7 +199,6 @@ import { Close, Download, Goods, Remove, Setting } from '@element-plus/icons-vue
 import { T as $T } from '@/i18n/index'
 import ConfigForm from '@/components/ConfigForm.vue'
 import { debounce, DebouncedFunc } from 'lodash'
-import type { IpcRendererEvent } from 'electron'
 import { handleStreamlinePluginName } from '~/universal/utils/common'
 import {
   OPEN_URL,
@@ -267,7 +266,7 @@ useIPCOn('hideLoading', () => {
   loading.value = false
 })
 
-useIPCOn(PICGO_HANDLE_PLUGIN_DONE, (evt: IpcRendererEvent, fullName: string) => {
+useIPCOn(PICGO_HANDLE_PLUGIN_DONE, (fullName: string) => {
   pluginList.value.forEach(item => {
     if (item.fullName === fullName || (item.name === fullName)) {
       item.ing = false
@@ -276,13 +275,13 @@ useIPCOn(PICGO_HANDLE_PLUGIN_DONE, (evt: IpcRendererEvent, fullName: string) => 
   loading.value = false
 })
 
-useIPCOn('pluginList', (evt: IpcRendererEvent, list: IPicGoPlugin[]) => {
+useIPCOn('pluginList', (list: IPicGoPlugin[]) => {
   pluginList.value = list
   pluginNameList.value = list.map(item => item.fullName)
   loading.value = false
 })
 
-useIPCOn('installPlugin', (evt: IpcRendererEvent, { success, body }: {
+useIPCOn('installPlugin', ({ success, body }: {
   success: boolean,
   body: string
 }) => {
@@ -295,7 +294,7 @@ useIPCOn('installPlugin', (evt: IpcRendererEvent, { success, body }: {
   })
 })
 
-useIPCOn('updateSuccess', (evt: IpcRendererEvent, plugin: string) => {
+useIPCOn('updateSuccess', (plugin: string) => {
   loading.value = false
   pluginList.value.forEach(item => {
     if (item.fullName === plugin) {
@@ -308,7 +307,7 @@ useIPCOn('updateSuccess', (evt: IpcRendererEvent, plugin: string) => {
   getPluginList()
 })
 
-useIPCOn('uninstallSuccess', (evt: IpcRendererEvent, plugin: string) => {
+useIPCOn('uninstallSuccess', (plugin: string) => {
   loading.value = false
   pluginList.value = pluginList.value.filter(item => {
     if (item.fullName === plugin) { // restore Uploader & Transformer after uninstalling
@@ -325,14 +324,14 @@ useIPCOn('uninstallSuccess', (evt: IpcRendererEvent, plugin: string) => {
   pluginNameList.value = pluginNameList.value.filter(item => item !== plugin)
 })
 
-useIPCOn(PICGO_CONFIG_PLUGIN, (evt: IpcRendererEvent, _currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: IPicGoPluginConfig[]) => {
+useIPCOn(PICGO_CONFIG_PLUGIN, (_currentType: 'plugin' | 'transformer' | 'uploader', _configName: string, _config: IPicGoPluginConfig[]) => {
   currentType.value = _currentType
   configName.value = _configName
   config.value = _config
   dialogVisible.value = true
 })
 
-useIPCOn(PICGO_HANDLE_PLUGIN_ING, (evt: IpcRendererEvent, fullName: string) => {
+useIPCOn(PICGO_HANDLE_PLUGIN_ING, (fullName: string) => {
   pluginList.value.forEach(item => {
     if (item.fullName === fullName || (item.name === fullName)) {
       item.ing = true
@@ -341,7 +340,7 @@ useIPCOn(PICGO_HANDLE_PLUGIN_ING, (evt: IpcRendererEvent, fullName: string) => {
   loading.value = true
 })
 
-useIPCOn(PICGO_TOGGLE_PLUGIN, (evt: IpcRendererEvent, fullName: string, enabled: boolean) => {
+useIPCOn(PICGO_TOGGLE_PLUGIN, (fullName: string, enabled: boolean) => {
   const plugin = pluginList.value.find(item => item.fullName === fullName)
   if (plugin) {
     plugin.enabled = enabled

--- a/src/renderer/pages/RenamePage.vue
+++ b/src/renderer/pages/RenamePage.vue
@@ -56,11 +56,7 @@ import { Close } from '@element-plus/icons-vue'
 import { GET_RENAME_FILE_NAME, RENAME_FILE_NAME } from '#/events/constants'
 import { sendToMain } from '@/utils/dataSender'
 import { T as $T } from '@/i18n/index'
-import {
-  ipcRenderer,
-  IpcRendererEvent
-} from 'electron'
-import { onBeforeUnmount, onBeforeMount, ref, reactive } from 'vue'
+import { onBeforeMount, ref, reactive } from 'vue'
 import { useIPCOn } from '@/hooks/useIPC'
 import { FormInstance } from 'element-plus'
 const id = ref<string | null>(null)
@@ -71,7 +67,7 @@ const form = reactive({
   originName: ''
 })
 
-const handleFileName = (event: IpcRendererEvent, newName: string, _originName: string, _id: string) => {
+const handleFileName = (newName: string, _originName: string, _id: string) => {
   form.fileName = newName
   form.originName = _originName
   id.value = _id
@@ -80,7 +76,7 @@ const handleFileName = (event: IpcRendererEvent, newName: string, _originName: s
 useIPCOn(RENAME_FILE_NAME, handleFileName)
 
 onBeforeMount(() => {
-  ipcRenderer.send(GET_RENAME_FILE_NAME)
+  sendToMain(GET_RENAME_FILE_NAME)
 })
 
 function confirmName () {
@@ -95,10 +91,6 @@ function cancel () {
   // if cancel, use origin file name
   sendToMain(`${RENAME_FILE_NAME}${id.value}`, form.originName)
 }
-
-onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners(RENAME_FILE_NAME)
-})
 
 </script>
 <script lang="ts">

--- a/src/renderer/pages/ShortKey.vue
+++ b/src/renderer/pages/ShortKey.vue
@@ -115,11 +115,11 @@
 </template>
 <script lang="ts" setup>
 import keyBinding from '@/utils/key-binding'
-import { ipcRenderer, IpcRendererEvent } from 'electron'
 import { TOGGLE_SHORTKEY_MODIFIED_MODE } from '#/events/constants'
 import { onBeforeUnmount, onBeforeMount, ref, watch } from 'vue'
 import { getConfig, sendToMain } from '@/utils/dataSender'
 import { T as $T } from '@/i18n/index'
+import { ipc } from '@/utils/bridge'
 
 const list = ref<IShortKeyConfig[]>([])
 const keyBindingVisible = ref(false)
@@ -177,7 +177,7 @@ async function confirmKeyBinding () {
   const config = Object.assign({}, list.value[currentIndex.value])
   config.key = shortKey.value
   sendToMain('updateShortKey', config, oldKey, config.from)
-  ipcRenderer.once('updateShortKeyResponse', (evt: IpcRendererEvent, result) => {
+  ipc.once('updateShortKeyResponse', (result: boolean) => {
     if (result) {
       keyBindingVisible.value = false
       list.value[currentIndex.value].key = shortKey.value

--- a/src/renderer/pages/Toolbox.vue
+++ b/src/renderer/pages/Toolbox.vue
@@ -170,7 +170,7 @@ const format = (percentage: number) => ''
 
 const ipc = useIPC()
 
-ipc.on(IRPCActionType.TOOLBOX_CHECK_RES, (event, { type, msg = '', status, value = '' }: IToolboxCheckRes) => {
+ipc.on(IRPCActionType.TOOLBOX_CHECK_RES, ({ type, msg = '', status, value = '' }: IToolboxCheckRes) => {
   fixList[type].status = status
   fixList[type].msg = msg
   fixList[type].value = value

--- a/src/renderer/pages/TrayPage.vue
+++ b/src/renderer/pages/TrayPage.vue
@@ -63,7 +63,6 @@
 
 <script lang="ts" setup>
 import { reactive, ref, onBeforeUnmount, onBeforeMount } from 'vue'
-import { ipcRenderer } from 'electron'
 import $$db from '@/utils/db'
 import { T as $T } from '@/i18n/index'
 import type { IResult } from '@picgo/store/dist/types'
@@ -72,7 +71,7 @@ import { IWindowList } from '#/types/enum'
 import { sendToMain } from '@/utils/dataSender'
 import { getRawData } from '@/utils/common'
 import { showNotification } from '@/utils/notification'
-import { IpcRendererEvent } from 'electron/renderer'
+import { ipc } from '@/utils/bridge'
 
 const files = ref<IResult<ImgInfo>[]>([])
 const notification = reactive({
@@ -82,6 +81,7 @@ const notification = reactive({
 
 const clipboardFiles = ref<ImgInfo[]>([])
 const uploadFlag = ref(false)
+const cleanupListeners: Array<() => void> = []
 
 // const reverseList = computed(() => files.value.slice().reverse())
 
@@ -95,7 +95,7 @@ async function getData () {
 
 async function copyTheLink (item: ImgInfo) {
   notification.body = item.imgUrl!
-  await ipcRenderer.invoke(PASTE_TEXT, getRawData(item))
+  await ipc.invoke(PASTE_TEXT, getRawData(item))
   showNotification({
     title: notification.title,
     body: notification.body
@@ -128,30 +128,29 @@ function uploadClipboardFiles () {
 onBeforeMount(() => {
   disableDragFile()
   getData()
-  ipcRenderer.on('dragFiles', async (event: IpcRendererEvent, _files: string[]) => {
+  cleanupListeners.push(ipc.on('dragFiles', async (_files: string[]) => {
     for (let i = 0; i < _files.length; i++) {
       const item = _files[i]
       await $$db.insert(item)
     }
     files.value = (await $$db.get<ImgInfo>({ orderBy: 'desc', limit: 5 })).data
-  })
-  ipcRenderer.on('clipboardFiles', (event: IpcRendererEvent, files: ImgInfo[]) => {
+  }))
+  cleanupListeners.push(ipc.on('clipboardFiles', (files: ImgInfo[]) => {
     clipboardFiles.value = files
-  })
-  ipcRenderer.on('uploadFiles', async () => {
+  }))
+  cleanupListeners.push(ipc.on('uploadFiles', async () => {
     files.value = (await $$db.get<ImgInfo>({ orderBy: 'desc', limit: 5 })).data
     uploadFlag.value = false
-  })
-  ipcRenderer.on('updateFiles', () => {
+  }))
+  cleanupListeners.push(ipc.on('updateFiles', () => {
     getData()
-  })
+  }))
 })
 
 onBeforeUnmount(() => {
-  ipcRenderer.removeAllListeners('dragFiles')
-  ipcRenderer.removeAllListeners('clipboardFiles')
-  ipcRenderer.removeAllListeners('uploadClipboardFiles')
-  ipcRenderer.removeAllListeners('updateFiles')
+  cleanupListeners.splice(0).forEach((cleanup) => {
+    cleanup()
+  })
 })
 </script>
 

--- a/src/renderer/pages/Upload.vue
+++ b/src/renderer/pages/Upload.vue
@@ -105,10 +105,6 @@ import $bus from '@/utils/bus'
 import { getFilePath } from '@/utils/common'
 import { saveConfig, sendToMain } from '@/utils/dataSender'
 import { CaretBottom, UploadFilled } from '@element-plus/icons-vue'
-import {
-  IpcRendererEvent,
-  ipcRenderer
-} from 'electron'
 import { ElMessage as $message, ElMessageBox } from 'element-plus'
 import { computed, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue'
 import {
@@ -123,6 +119,7 @@ import {
   parseNewlineSeparatedUrls
 } from '~/universal/utils/common'
 import { useStore } from '@/hooks/useStore'
+import { ipc } from '@/utils/bridge'
 const dragover = ref(false)
 const progress = ref(0)
 const showProgress = ref(false)
@@ -147,8 +144,10 @@ const configName = computed(() => {
   return 'Default'
 })
 const $confirm = ElMessageBox.confirm
+let cleanupUploadProgress = () => {}
+let cleanupSyncPicBed = () => {}
 onBeforeMount(() => {
-  ipcRenderer.on('uploadProgress', (event: IpcRendererEvent, _progress: number) => {
+  cleanupUploadProgress = ipc.on('uploadProgress', (_progress: number) => {
     if (_progress !== -1) {
       showProgress.value = true
       progress.value = _progress
@@ -159,7 +158,7 @@ onBeforeMount(() => {
   })
   store?.refreshAppConfig()
   store?.refreshPicBeds()
-  ipcRenderer.on('syncPicBed', () => {
+  cleanupSyncPicBed = ipc.on('syncPicBed', () => {
     store?.refreshAppConfig()
   })
   $bus.on(SHOW_INPUT_BOX_RESPONSE, handleInputBoxValue)
@@ -181,8 +180,8 @@ function onProgressChange (val: number) {
 
 onBeforeUnmount(() => {
   $bus.off(SHOW_INPUT_BOX_RESPONSE)
-  ipcRenderer.removeAllListeners('uploadProgress')
-  ipcRenderer.removeAllListeners('syncPicBed')
+  cleanupUploadProgress()
+  cleanupSyncPicBed()
 })
 
 async function onDrop (e: DragEvent) {
@@ -274,8 +273,9 @@ function openUploadWindow () {
 }
 
 function onChange (e: any) {
-  ipcSendFiles(e.target.files);
-  (document.getElementById('file-uploader') as HTMLInputElement).value = ''
+  ipcSendFiles(e.target.files)
+  const fileUploader = document.getElementById('file-uploader') as HTMLInputElement
+  fileUploader.value = ''
 }
 
 function ipcSendFiles (files: FileList) {

--- a/src/renderer/pages/components/settings/customArea/ChoosePicBed.vue
+++ b/src/renderer/pages/components/settings/customArea/ChoosePicBed.vue
@@ -22,7 +22,6 @@ import { GET_PICBEDS } from '#/events/constants'
 import { saveConfig, sendToMain } from '@/utils/dataSender'
 import { useIPCOn } from '@/hooks/useIPC'
 import { useVModel } from '@/hooks/useVModel'
-import { IpcRendererEvent } from 'electron'
 
 interface IProps {
   showPicBedList: string[]
@@ -52,7 +51,7 @@ onBeforeMount(() => {
   useIPCOn(GET_PICBEDS, getPicBeds)
 })
 
-function getPicBeds (event: IpcRendererEvent, picBeds: IPicBedType[]) {
+function getPicBeds (picBeds: IPicBedType[]) {
   picBed.value = picBeds
   showPicBedList.value = picBed.value.map(item => {
     if (item.visible) {

--- a/src/renderer/pages/components/settings/selectArea/SelectAreaSettings.vue
+++ b/src/renderer/pages/components/settings/selectArea/SelectAreaSettings.vue
@@ -20,7 +20,7 @@ import { saveConfig, sendToMain } from '@/utils/dataSender'
 import { GET_PICBEDS } from '~/universal/events/constants'
 import SelectFormItem from '@/components/settings/SelectFormItem.vue'
 import { IStartupMode } from '~/universal/types/enum'
-import { isMacOS } from '~/universal/utils/common'
+import { isMacOSPlatform } from '@/utils/bridge'
 
 interface IProps {
   settings: ISettingForm
@@ -42,7 +42,7 @@ const startupModeList = [
   {
     label: $T('SETTINGS_STARTUP_MODE_MINI_WINDOW'),
     value: IStartupMode.SHOW_MINI_WINDOW,
-    hide: isMacOS
+    hide: isMacOSPlatform()
   },
   {
     label: $T('SETTINGS_STARTUP_MODE_HIDE'),

--- a/src/renderer/pages/picbeds/index.vue
+++ b/src/renderer/pages/picbeds/index.vue
@@ -51,9 +51,6 @@ import { useRoute, useRouter } from 'vue-router'
 import ConfigForm from '@/components/ConfigForm.vue'
 import { ElMessage } from 'element-plus'
 // import mixin from '@/utils/ConfirmButtonMixin'
-import {
-  IpcRendererEvent
-} from 'electron'
 import { GET_PICBED_CONFIG } from '~/universal/events/constants'
 import { useIPCOn } from '@/hooks/useIPC'
 import { useStore } from '@/hooks/useStore'
@@ -93,7 +90,7 @@ const handleConfirm = async () => {
   }
 }
 
-function getPicBeds (event: IpcRendererEvent, _config: IPicGoPluginConfig[], name: string) {
+function getPicBeds (_config: IPicGoPluginConfig[], name: string) {
   config.value = _config
   picBedName.value = name
 }

--- a/src/renderer/utils/analytics.ts
+++ b/src/renderer/utils/analytics.ts
@@ -3,8 +3,8 @@ import {
   TALKING_DATA_APPID, TALKING_DATA_DEVICE_ID_EVENT, TALKING_DATA_EVENT
 } from '~/universal/events/constants'
 import pkg from 'root/package.json'
-import { ipcRenderer } from 'electron'
 import { handleTalkingDataEvent } from './common'
+import { ipc } from './bridge'
 const { version } = pkg
 
 export const initTalkingData = () => {
@@ -18,12 +18,14 @@ export const initTalkingData = () => {
   }, 0)
 }
 
-ipcRenderer.on(TALKING_DATA_EVENT, (_, data: ITalkingDataOptions) => {
+ipc.removeAllListeners(TALKING_DATA_EVENT)
+ipc.on(TALKING_DATA_EVENT, (data: ITalkingDataOptions) => {
   handleTalkingDataEvent(data)
 })
 // 0：ANONYMOUS，匿名账号；
 // 1：REGISTERED，自有帐户显性注册；
-ipcRenderer.on(TALKING_DATA_DEVICE_ID_EVENT, (_, deviceId: string) => {
+ipc.removeAllListeners(TALKING_DATA_DEVICE_ID_EVENT)
+ipc.on(TALKING_DATA_DEVICE_ID_EVENT, (deviceId: string) => {
   window.TDAPP.register({
     profileId: deviceId,
     profileType: 1
@@ -32,5 +34,5 @@ ipcRenderer.on(TALKING_DATA_DEVICE_ID_EVENT, (_, deviceId: string) => {
     profileId: deviceId,
     profileType: 1
   })
-  ipcRenderer.send(REGISTER_DEVICE_ID)
+  ipc.send(REGISTER_DEVICE_ID)
 })

--- a/src/renderer/utils/bridge.ts
+++ b/src/renderer/utils/bridge.ts
@@ -1,0 +1,135 @@
+let bridgeApi: BridgeApi | null = null
+
+const resolveBridgeApi = (): BridgeApi => {
+  if (bridgeApi) {
+    return bridgeApi
+  }
+
+  const windowBridgeApi = typeof window !== 'undefined' ? window.bridgeApi : undefined
+  const globalBridgeApi = (globalThis as { bridgeApi?: BridgeApi }).bridgeApi
+  const resolvedBridgeApi = windowBridgeApi || globalBridgeApi
+
+  if (!resolvedBridgeApi) {
+    throw new Error('bridgeApi is unavailable. Ensure the Electron preload script loaded successfully and exposed window.bridgeApi.')
+  }
+
+  bridgeApi = resolvedBridgeApi
+
+  return bridgeApi
+}
+
+const listenerCleanupMap = new Map<string, Map<BridgeIpcListener, Set<BridgeIpcCleanup>>>()
+
+const getChannelListeners = (channel: string) => {
+  let channelListeners = listenerCleanupMap.get(channel)
+  if (!channelListeners) {
+    channelListeners = new Map()
+    listenerCleanupMap.set(channel, channelListeners)
+  }
+  return channelListeners
+}
+
+const untrackCleanup = (channel: string, listener: BridgeIpcListener, cleanup: BridgeIpcCleanup) => {
+  const channelListeners = listenerCleanupMap.get(channel)
+  if (!channelListeners) return
+
+  const cleanupSet = channelListeners.get(listener)
+  if (!cleanupSet) return
+
+  cleanupSet.delete(cleanup)
+  if (cleanupSet.size === 0) {
+    channelListeners.delete(listener)
+  }
+
+  if (channelListeners.size === 0) {
+    listenerCleanupMap.delete(channel)
+  }
+}
+
+const trackCleanup = (channel: string, listener: BridgeIpcListener, cleanup: BridgeIpcCleanup) => {
+  const channelListeners = getChannelListeners(channel)
+  const cleanupSet = channelListeners.get(listener) || new Set<BridgeIpcCleanup>()
+  const trackedCleanup = () => {
+    cleanup()
+    untrackCleanup(channel, listener, trackedCleanup)
+  }
+
+  cleanupSet.add(trackedCleanup)
+  channelListeners.set(listener, cleanupSet)
+
+  return trackedCleanup
+}
+
+export const ipc = {
+  send: (channel: string, ...args: unknown[]) => resolveBridgeApi().ipc.send(channel, ...args),
+  invoke: <T>(channel: string, ...args: unknown[]) => resolveBridgeApi().ipc.invoke<T>(channel, ...args),
+  on: (channel: string, listener: BridgeIpcListener) => {
+    const cleanup = resolveBridgeApi().ipc.on(channel, listener)
+    return trackCleanup(channel, listener, cleanup)
+  },
+  once: (channel: string, listener: BridgeIpcListener) => {
+    let trackedCleanup: BridgeIpcCleanup = () => {}
+
+    const wrappedListener: BridgeIpcListener = (...args) => {
+      untrackCleanup(channel, listener, trackedCleanup)
+      listener(...args)
+    }
+
+    const cleanup = resolveBridgeApi().ipc.once(channel, wrappedListener)
+    trackedCleanup = trackCleanup(channel, listener, cleanup)
+
+    return trackedCleanup
+  },
+  off: (channel: string, listener: BridgeIpcListener) => {
+    const cleanupSet = listenerCleanupMap.get(channel)?.get(listener)
+    if (!cleanupSet) return
+
+    Array.from(cleanupSet).forEach((cleanup) => {
+      cleanup()
+    })
+  },
+  removeAllListeners: (channel: string) => {
+    resolveBridgeApi().ipc.removeAllListeners(channel)
+    listenerCleanupMap.delete(channel)
+  }
+}
+
+export const clipboard = {
+  writeText: (text: string) => resolveBridgeApi().clipboard.writeText(text)
+}
+
+export const webUtils = {
+  getPathForFile: (file: File) => resolveBridgeApi().webUtils.getPathForFile(file)
+}
+
+export const webFrame = {
+  setVisualZoomLevelLimits: (minimumLevel: number, maximumLevel: number) => {
+    resolveBridgeApi().webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)
+  }
+}
+
+export const env: BridgeApi['env'] = {
+  get platform () {
+    return resolveBridgeApi().env.platform
+  },
+  get isDev () {
+    return resolveBridgeApi().env.isDev
+  }
+}
+
+export const picgoI18n: BridgeApi['i18n'] = {
+  ObjectAdapter: {
+    create: (locales: Record<string, ILocales>) => resolveBridgeApi().i18n.ObjectAdapter.create(locales)
+  },
+  I18n: {
+    createFromLocales: (locales: Record<string, ILocales>, defaultLanguage: string) => {
+      return resolveBridgeApi().i18n.I18n.createFromLocales(locales, defaultLanguage)
+    }
+  }
+}
+
+export const getPlatform = () => env.platform
+export const isDevEnv = () => env.isDev
+export const isMacOSPlatform = () => env.platform === 'darwin'
+export const isWindowsPlatform = () => env.platform === 'win32'
+export const isLinuxPlatform = () => env.platform === 'linux'

--- a/src/renderer/utils/bridge.ts
+++ b/src/renderer/utils/bridge.ts
@@ -18,80 +18,12 @@ const resolveBridgeApi = (): BridgeApi => {
   return bridgeApi
 }
 
-const listenerCleanupMap = new Map<string, Map<BridgeIpcListener, Set<BridgeIpcCleanup>>>()
-
-const getChannelListeners = (channel: string) => {
-  let channelListeners = listenerCleanupMap.get(channel)
-  if (!channelListeners) {
-    channelListeners = new Map()
-    listenerCleanupMap.set(channel, channelListeners)
-  }
-  return channelListeners
-}
-
-const untrackCleanup = (channel: string, listener: BridgeIpcListener, cleanup: BridgeIpcCleanup) => {
-  const channelListeners = listenerCleanupMap.get(channel)
-  if (!channelListeners) return
-
-  const cleanupSet = channelListeners.get(listener)
-  if (!cleanupSet) return
-
-  cleanupSet.delete(cleanup)
-  if (cleanupSet.size === 0) {
-    channelListeners.delete(listener)
-  }
-
-  if (channelListeners.size === 0) {
-    listenerCleanupMap.delete(channel)
-  }
-}
-
-const trackCleanup = (channel: string, listener: BridgeIpcListener, cleanup: BridgeIpcCleanup) => {
-  const channelListeners = getChannelListeners(channel)
-  const cleanupSet = channelListeners.get(listener) || new Set<BridgeIpcCleanup>()
-  const trackedCleanup = () => {
-    cleanup()
-    untrackCleanup(channel, listener, trackedCleanup)
-  }
-
-  cleanupSet.add(trackedCleanup)
-  channelListeners.set(listener, cleanupSet)
-
-  return trackedCleanup
-}
-
 export const ipc = {
   send: (channel: string, ...args: unknown[]) => resolveBridgeApi().ipc.send(channel, ...args),
   invoke: <T>(channel: string, ...args: unknown[]) => resolveBridgeApi().ipc.invoke<T>(channel, ...args),
-  on: (channel: string, listener: BridgeIpcListener) => {
-    const cleanup = resolveBridgeApi().ipc.on(channel, listener)
-    return trackCleanup(channel, listener, cleanup)
-  },
-  once: (channel: string, listener: BridgeIpcListener) => {
-    let trackedCleanup: BridgeIpcCleanup = () => {}
-
-    const wrappedListener: BridgeIpcListener = (...args) => {
-      untrackCleanup(channel, listener, trackedCleanup)
-      listener(...args)
-    }
-
-    const cleanup = resolveBridgeApi().ipc.once(channel, wrappedListener)
-    trackedCleanup = trackCleanup(channel, listener, cleanup)
-
-    return trackedCleanup
-  },
-  off: (channel: string, listener: BridgeIpcListener) => {
-    const cleanupSet = listenerCleanupMap.get(channel)?.get(listener)
-    if (!cleanupSet) return
-
-    Array.from(cleanupSet).forEach((cleanup) => {
-      cleanup()
-    })
-  },
-  removeAllListeners: (channel: string) => {
-    resolveBridgeApi().ipc.removeAllListeners(channel)
-    listenerCleanupMap.delete(channel)
-  }
+  on: (channel: string, listener: BridgeIpcListener) => resolveBridgeApi().ipc.on(channel, listener),
+  once: (channel: string, listener: BridgeIpcListener) => resolveBridgeApi().ipc.once(channel, listener),
+  removeAllListeners: (channel: string) => resolveBridgeApi().ipc.removeAllListeners(channel)
 }
 
 export const clipboard = {

--- a/src/renderer/utils/common.ts
+++ b/src/renderer/utils/common.ts
@@ -1,9 +1,9 @@
 import { isReactive, isRef, toRaw, unref } from 'vue'
 import { sendToMain } from './dataSender'
 import { OPEN_URL, PICGO_OPEN_FILE } from '~/universal/events/constants'
-import { webUtils } from 'electron'
+import { env, webUtils } from './bridge'
 
-const isDevelopment = process.env.NODE_ENV !== 'production'
+const isDevelopment = env.isDev
 export const handleTalkingDataEvent = (data: ITalkingDataOptions) => {
   const { EventId, Label = '', MapKv = {} } = data
   MapKv.from = window.location.href

--- a/src/renderer/utils/dataSender.ts
+++ b/src/renderer/utils/dataSender.ts
@@ -1,8 +1,8 @@
 import { GET_PICBEDS, PICGO_GET_CONFIG, PICGO_SAVE_CONFIG, RPC_ACTIONS } from '#/events/constants'
-import { IpcRendererEvent, ipcRenderer } from 'electron'
 import { v4 as uuid } from 'uuid'
 import { IRPCActionType } from '~/universal/types/enum'
 import { getRawData } from './common'
+import { ipc } from './bridge'
 
 export async function saveConfig (_config: IObj | string, value?: any) {
   let config
@@ -13,41 +13,42 @@ export async function saveConfig (_config: IObj | string, value?: any) {
   } else {
     config = getRawData(_config)
   }
-  await ipcRenderer.invoke(PICGO_SAVE_CONFIG, config)
+  await ipc.invoke(PICGO_SAVE_CONFIG, config)
 }
 
 export function getConfig<T> (key?: string): Promise<T | undefined> {
   return new Promise((resolve) => {
     const callbackId = uuid()
-    const callback = (event: IpcRendererEvent, config: T | undefined, returnCallbackId: string) => {
+    let cleanup = () => {}
+    const callback = (config: T | undefined, returnCallbackId: string) => {
       if (returnCallbackId === callbackId) {
         resolve(config)
-        ipcRenderer.removeListener(PICGO_GET_CONFIG, callback)
+        cleanup()
       }
     }
-    ipcRenderer.on(PICGO_GET_CONFIG, callback)
-    ipcRenderer.send(PICGO_GET_CONFIG, key, callbackId)
+    cleanup = ipc.on(PICGO_GET_CONFIG, callback)
+    ipc.send(PICGO_GET_CONFIG, key, callbackId)
   })
 }
 
 export function getPicBeds (): Promise<IPicBedType[]> {
   return new Promise((resolve) => {
-    ipcRenderer.once(GET_PICBEDS, (_event: IpcRendererEvent, picBeds: IPicBedType[]) => {
+    ipc.once(GET_PICBEDS, (picBeds: IPicBedType[]) => {
       resolve(picBeds)
     })
-    ipcRenderer.send(GET_PICBEDS)
+    ipc.send(GET_PICBEDS)
   })
 }
 
 /**
  * Invoke an RPC action and await its return value.
  *
- * This uses `ipcRenderer.invoke(RPC_ACTIONS, action, args)` which is backed by
+ * This uses `bridgeApi.ipc.invoke(RPC_ACTIONS, action, args)` which is backed by
  * `ipcMain.handle(RPC_ACTIONS, ...)` in the main process RPC server.
  */
 export function invokeRPC<T> (action: IRPCActionType, ...args: any[]): Promise<IRPCResult<T>> {
   const data = getRawData(args)
-  return ipcRenderer.invoke(RPC_ACTIONS, action, data) as Promise<IRPCResult<T>>
+  return ipc.invoke<IRPCResult<T>>(RPC_ACTIONS, action, data)
 }
 
 /**
@@ -57,7 +58,7 @@ export function invokeRPC<T> (action: IRPCActionType, ...args: any[]): Promise<I
  */
 export function sendRPC (action: IRPCActionType, ...args: any[]): void {
   const data = getRawData(args)
-  ipcRenderer.send(RPC_ACTIONS, action, data)
+  ipc.send(RPC_ACTIONS, action, data)
 }
 
 /**
@@ -65,5 +66,5 @@ export function sendRPC (action: IRPCActionType, ...args: any[]): void {
  */
 export function sendToMain (channel: string, ...args: any[]) {
   const data = getRawData(args)
-  ipcRenderer.send(channel, ...data)
+  ipc.send(channel, ...data)
 }

--- a/src/renderer/utils/db.ts
+++ b/src/renderer/utils/db.ts
@@ -8,9 +8,9 @@ import {
 } from '#/events/constants'
 import { IGalleryDB } from '#/types/extra-vue'
 import { IFilter, IGetResult, IObject, IResult } from '@picgo/store/dist/types'
-import { IpcRendererEvent, ipcRenderer } from 'electron'
 import { v4 as uuid } from 'uuid'
 import { getRawData } from './common'
+import { ipc } from './bridge'
 export class GalleryDB implements IGalleryDB {
   async get<T> (filter?: IFilter): Promise<IGetResult<T>> {
     const res = await this.msgHandler<IGetResult<T>>(PICGO_GET_DB, filter)
@@ -45,15 +45,16 @@ export class GalleryDB implements IGalleryDB {
   private msgHandler<T> (method: string, ...args: any[]): Promise<T> {
     return new Promise((resolve) => {
       const callbackId = uuid()
-      const callback = (event: IpcRendererEvent, data: T, returnCallbackId: string) => {
+      let cleanup = () => {}
+      const callback = (data: T, returnCallbackId: string) => {
         if (returnCallbackId === callbackId) {
           resolve(data)
-          ipcRenderer.removeListener(method, callback)
+          cleanup()
         }
       }
       const data = getRawData(args)
-      ipcRenderer.on(method, callback)
-      ipcRenderer.send(method, ...data, callbackId)
+      cleanup = ipc.on(method, callback)
+      ipc.send(method, ...data, callbackId)
     })
   }
 }

--- a/src/renderer/utils/key-binding.ts
+++ b/src/renderer/utils/key-binding.ts
@@ -1,4 +1,5 @@
 import keycode from 'keycode'
+import { isMacOSPlatform } from './bridge'
 
 const isSpecialKey = (keyCode: number) => {
   const keyArr = [
@@ -13,8 +14,7 @@ const isSpecialKey = (keyCode: number) => {
 }
 
 const keyDetect = (event: KeyboardEvent) => {
-  // TODO: remove process
-  const meta = process.platform === 'darwin' ? 'Cmd' : 'Super'
+  const meta = isMacOSPlatform() ? 'Cmd' : 'Super'
   const specialKey = {
     Ctrl: event.ctrlKey,
     Shift: event.shiftKey,

--- a/src/renderer/utils/mainMixin.ts
+++ b/src/renderer/utils/mainMixin.ts
@@ -1,7 +1,7 @@
 import { ComponentOptions } from 'vue'
 import { FORCE_UPDATE, GET_PICBEDS } from '~/universal/events/constants'
 import bus from '~/renderer/utils/bus'
-import { ipcRenderer } from 'electron'
+import { ipc } from './bridge'
 export const mainMixin: ComponentOptions = {
   inject: ['forceUpdateTime'],
 
@@ -19,7 +19,7 @@ export const mainMixin: ComponentOptions = {
       bus.emit(FORCE_UPDATE)
     },
     getPicBeds () {
-      ipcRenderer.send(GET_PICBEDS)
+      ipc.send(GET_PICBEDS)
     }
   }
 }

--- a/src/renderer/utils/notification.ts
+++ b/src/renderer/utils/notification.ts
@@ -1,13 +1,13 @@
-import { ipcRenderer } from 'electron'
 import { v4 as uuid } from 'uuid'
 import { sendRPC } from './dataSender'
 import { PICGO_NOTIFICATION_CLICKED } from '~/universal/events/constants'
 import { IRPCActionType } from '~/universal/types/enum'
+import { ipc } from './bridge'
 
 const notificationCallbacks = new Map<string, () => void>()
 const MAX_CALLBACK_LIMIT = 10
 
-const handleNotificationClick = (_event: Electron.IpcRendererEvent, id: string) => {
+const handleNotificationClick = (id: string) => {
   const callback = notificationCallbacks.get(id)
   if (!callback) return
   try {
@@ -18,8 +18,8 @@ const handleNotificationClick = (_event: Electron.IpcRendererEvent, id: string) 
 }
 
 // HMR Protection: Remove existing listener before adding a new one
-ipcRenderer.removeAllListeners(PICGO_NOTIFICATION_CLICKED)
-ipcRenderer.on(PICGO_NOTIFICATION_CLICKED, handleNotificationClick)
+ipc.removeAllListeners(PICGO_NOTIFICATION_CLICKED)
+ipc.on(PICGO_NOTIFICATION_CLICKED, handleNotificationClick)
 
 interface NotificationOptions {
   title: string

--- a/src/universal/types/electron.d.ts
+++ b/src/universal/types/electron.d.ts
@@ -18,4 +18,4 @@ declare interface IWindowManager {
   getAvailableWindow: () => BrowserWindow
 }
 
-type IpcRendererListener = (event: import('electron').IpcRendererEvent, ...args: any[]) => void
+type IpcRendererListener = (...args: any[]) => void

--- a/src/universal/types/shims-tsx.d.ts
+++ b/src/universal/types/shims-tsx.d.ts
@@ -23,7 +23,6 @@ declare global {
       invoke: <T>(channel: string, ...args: unknown[]) => Promise<T>
       on: (channel: string, listener: BridgeIpcListener) => BridgeIpcCleanup
       once: (channel: string, listener: BridgeIpcListener) => BridgeIpcCleanup
-      off: (channel: string, listener: BridgeIpcListener) => void
       removeAllListeners: (channel: string) => void
     }
     clipboard: {

--- a/src/universal/types/shims-tsx.d.ts
+++ b/src/universal/types/shims-tsx.d.ts
@@ -1,8 +1,52 @@
 import Vue, { VNode } from 'vue'
 
 declare global {
-  interface ElectronApi {
-    getFilePath: (file: File) => string
+  type BridgeIpcListener = (...args: any[]) => void
+  type BridgeIpcCleanup = () => void
+
+  interface BridgeObjectAdapter {
+    getLocale: (language: string) => ILocales | undefined
+    setLocales: (locales: Record<string, ILocales>) => void
+    setLocale: (language: string, locale: ILocales) => void
+  }
+
+  interface BridgeI18nInstance {
+    getLanguage: () => string
+    setLanguage: (language: string) => void
+    setDefaultLanguage: (language: string) => void
+    translate: (key: ILocalesKey, args?: IStringKeyMap) => string
+  }
+
+  interface BridgeApi {
+    ipc: {
+      send: (channel: string, ...args: unknown[]) => void
+      invoke: <T>(channel: string, ...args: unknown[]) => Promise<T>
+      on: (channel: string, listener: BridgeIpcListener) => BridgeIpcCleanup
+      once: (channel: string, listener: BridgeIpcListener) => BridgeIpcCleanup
+      off: (channel: string, listener: BridgeIpcListener) => void
+      removeAllListeners: (channel: string) => void
+    }
+    clipboard: {
+      writeText: (text: string) => void
+    }
+    webUtils: {
+      getPathForFile: (file: File) => string
+    }
+    webFrame: {
+      setVisualZoomLevelLimits: (minimumLevel: number, maximumLevel: number) => void
+    }
+    env: {
+      platform: NodeJS.Platform
+      isDev: boolean
+    }
+    i18n: {
+      ObjectAdapter: {
+        create: (locales: Record<string, ILocales>) => BridgeObjectAdapter
+      }
+      I18n: {
+        createFromLocales: (locales: Record<string, ILocales>, defaultLanguage: string) => BridgeI18nInstance
+      }
+    }
   }
 
   namespace JSX {
@@ -16,7 +60,7 @@ declare global {
   }
 
   interface Window {
-    electronApi: ElectronApi
+    bridgeApi: BridgeApi
     TDAPP: {
       onEvent: (EventId: string, Label?: string, MapKv?: IStringKeyMap) => void
       register: (opt: {

--- a/src/universal/utils/common.ts
+++ b/src/universal/utils/common.ts
@@ -1,3 +1,5 @@
+const runtimeProcess = typeof process !== 'undefined' ? process : undefined
+
 export const isUrl = (url: string): boolean => (url.startsWith('http://') || url.startsWith('https://'))
 
 export interface IParseNewlineSeparatedUrlsResult {
@@ -130,7 +132,7 @@ export const enforceNumber = (num: number | string) => {
   return isNaN(Number(num)) ? 0 : Number(num)
 }
 
-export const isDev = process.env.NODE_ENV === 'development'
+export const isDev = runtimeProcess?.env.NODE_ENV === 'development'
 
 export const trimValues = (obj: IStringKeyMap) => {
   const newObj = {} as IStringKeyMap
@@ -140,6 +142,6 @@ export const trimValues = (obj: IStringKeyMap) => {
   return newObj
 }
 
-export const isMacOS = process.platform === 'darwin'
-export const isWindows = process.platform === 'win32'
-export const isLinux = process.platform === 'linux'
+export const isMacOS = runtimeProcess?.platform === 'darwin'
+export const isWindows = runtimeProcess?.platform === 'win32'
+export const isLinux = runtimeProcess?.platform === 'linux'


### PR DESCRIPTION
## Summary
- migrate renderer-side Electron and Node runtime access to the preload `bridgeApi`
- enable `contextIsolation`, wire all windows to preload, and bundle preload i18n usage so sandboxed preload can load successfully
- align renderer bridge tests with the new preload bridge access pattern

## Testing
- pnpm check
- pnpm build
- pnpm test
- pnpm dev
