### PR TITLE
:pencil: Docs: fix `https//` typo in Chinese FAQ #1

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -10,7 +10,7 @@ This is usually because the `Set URL` (access URL) in your Qiniu image host conf
 
 Reference: [issue#79](https://github.com/Molunerfinn/PicGo/issues/79)
 
-通常是你的七牛图床配置里的`设定访问网址`没有加上`http://`或者`https//`头。
+通常是你的七牛图床配置里的`设定访问网址`没有加上`http://`或者`https://`头。
 
 参考：[issue#79](https://github.com/Molunerfinn/PicGo/issues/79)
 


### PR DESCRIPTION
Line 13 of FAQ.md has `https//` (no colon) in the Chinese translation of FAQ #1, while the English line above (line 9) uses the correct `https://`. This brings the Chinese version into agreement with the English.