### PR TITLE
fix(i18n): support dynamic translation for command labels

### DIFF
--- a/src/main/apis/app/shortKey/shortKeyHandler.ts
+++ b/src/main/apis/app/shortKey/shortKeyHandler.ts
@@ -89,6 +89,7 @@ class ShortKeyHandler {
           enable: true,
           name: config.name,
           label: config.label,
+          labelKey: config.labelKey,
           key: config.key
         }
       })

--- a/src/renderer/pages/ShortKey.vue
+++ b/src/renderer/pages/ShortKey.vue
@@ -19,7 +19,7 @@
             :label="$T('SHORTCUT_NAME')"
           >
             <template #default="scope">
-              {{ scope.row.label ? scope.row.label : scope.row.name }}
+              {{ scope.row.labelKey ? $T(scope.row.labelKey) : (scope.row.label ? scope.row.label : scope.row.name) }}
             </template>
           </el-table-column>
           <el-table-column

--- a/src/universal/types/types.d.ts
+++ b/src/universal/types/types.d.ts
@@ -77,6 +77,7 @@ interface IShortKeyConfig {
   key: string // 按键
   name: string
   label: string
+  labelKey?: string
   from?: string
 }
 
@@ -84,6 +85,7 @@ interface IPluginShortKeyConfig {
   key: string
   name: string
   label: string
+  labelKey?: string
   handle: IShortKeyHandler
 }
 


### PR DESCRIPTION
## Summary

Fixes #1188.

Plugins register commands with `ctx.i18n.translate()` which resolves to a static string at registration time. When the user switches languages, these labels don't update because they're stored as resolved strings in config.

## Fix

Add optional `labelKey` property to `IShortKeyConfig` and `IPluginShortKeyConfig`. When `labelKey` is provided, the UI uses it to dynamically translate the label via `T()` instead of using the static `label` string.

### Changes

1. **types.d.ts**: Added `labelKey?: string` to both config interfaces
2. **shortKeyHandler.ts**: Save `labelKey` to config when registering commands
3. **ShortKey.vue**: Use `T(labelKey)` for translation if `labelKey` exists

### Backward Compatibility

Existing plugins that only provide `label` still work as before. New plugins can provide `labelKey` for dynamic translation:

```js
const commands = (ctx: IPicGo) => [
  {
    label: ctx.i18n.translate('PIC_GDRIVE_COMMAND_UPLOAD'),
    labelKey: 'PIC_GDRIVE_COMMAND_UPLOAD',
    key: 'Ctrl+Alt+0',
    name: 'uploadToGDrive',
    handle: uploadHandler
  }
]
```

When the user switches from English to Chinese, the label will now update from "Upload to Google Drive" to the Chinese translation.