### PR TITLE
:bug: Fix(gui): mini window ignores startup HIDE mode on Linux

### DIFF
--- a/src/main/apis/app/window/windowList.ts
+++ b/src/main/apis/app/window/windowList.ts
@@ -162,7 +162,7 @@ windowList.set(IWindowList.MINI_WINDOW, {
     const obj: IBrowserWindowOptions = {
       height: 64,
       width: 64,
-      show: isLinux,
+      show: false,
       frame: false,
       fullscreenable: false,
       skipTaskbar: true,


### PR DESCRIPTION
## 问题描述

Linux 下将启动模式设置为「隐藏」（静默启动）后，每次启动 mini 窗口仍然会弹出来。

## 根因分析

mini 窗口在 `SETTING_WINDOW` 的 callback 中被无条件创建（`src/main/apis/app/window/windowList.ts:154`）：

```typescript
// SETTING_WINDOW callback
windowManager.create(IWindowList.MINI_WINDOW)  // 无论启动模式如何都会执行
```

创建时传入了 `show: isLinux`，Linux 下为 `true`，导致构造完成即立即显示。而 `src/main/lifeCycle/index.ts:93` 中虽然有 `isWindowShouldShowOnStartup()` 判断，仅当启动模式为「显示 mini 窗口」时才调用 `.show()`，但此时 mini mindow 已经在 setting window 创建时完成了创建并显示。

## 修复

将 `show: isLinux` 改为 `show: false`。lifecycle 中的 `isWindowShouldShowOnStartup()` 已经会在启动模式为「显示 mini 窗口」时正确调用 `.show()`。其余触发场景（托盘点击、快捷键、IPC 事件）也都是显式调用 `.show()`，不受影响。

## 修复后的行为

| 启动模式 | 启动时 mini 窗口 |
|---|---|
| 隐藏 | 不显示 |
| 显示 mini 窗口 | 显示 |
| 显示主窗口 | 显示主窗口，mini 隐藏 |

已在 linux 环境验证行为与表格描述一致，使用环境为 Ubuntu 24.04 LTS + wayland