### PR TITLE
:bug: Fix(gui): 移除 backgroundThrottling: false 修复 macOS GPU 进程空转

### DIFF
--- a/src/main/apis/app/window/windowList.ts
+++ b/src/main/apis/app/window/windowList.ts
@@ -25,8 +25,7 @@ const defaultWebPreferences = {
   preload: path.join(__dirname, '../preload/index.js'),
   nodeIntegration: false,
   contextIsolation: true,
-  nodeIntegrationInWorker: false,
-  backgroundThrottling: false
+  nodeIntegrationInWorker: false
 }
 
 const handleWindowParams = (windowURL: string) => {


### PR DESCRIPTION
Fixes #1434

## 改动

移除 `defaultWebPreferences` 中的 `backgroundThrottling: false`，恢复 Electron 默认值。

```diff
 const defaultWebPreferences = {
   preload: path.join(__dirname, '../preload/index.js'),
   nodeIntegration: false,
   contextIsolation: true,
-  nodeIntegrationInWorker: false,
-  backgroundThrottling: false
+  nodeIntegrationInWorker: false
 }
```

## 原因

macOS 上该配置会让 `PicGo Helper (GPU)` 进程持续出帧：实测 4 小时 19 分累计约 100 分钟 CPU（约 36% 单核），关闭窗口后占用不下降，进程不回到 idle。

Electron 在 macOS 上无条件禁用了 `MacWebContentsOcclusion`（`shell/browser/feature_list.cc`），系统的窗口遮挡检测因此失效；叠加 `backgroundThrottling: false` 禁止后台降频，合成器便按刷新率持续出帧。详细数据与堆栈见 #1434。

## 关于这个配置

它从项目首个 commit 就存在（`d1b9e0f5`，2017-11-28），未找到说明动机的 commit message。当时同一窗口配置里还有 `vibrancy: 'ultra-dark'` 和 `transparent: true`，而这两项在当前 dev 上已分别被移除和改为 `false`（仅 MINI_WINDOW 保留 transparent，且 macOS 上 `isValid: false`）。

`070ce2b`（electron-vite 迁移 #1361）把原先 5 处各自的副本合并进了共享的 `defaultWebPreferences`，看起来是重构去重。

## 影响面

上传逻辑在主进程（Node 侧），不受渲染进程节流影响。渲染层应该没有需要在后台持续运行的动画或定时器。

如果某个窗口确实需要保留该设置，我可以改成只对该窗口单独指定——请告知倾向。

## 测试状态

**需要坦白说明：我尚未构建修改版验证该改动确实能消除 CPU 占用。**

已验证：
- [x] 问题存在，且根因定位到该配置（数据见 #1434）

未验证：
- [ ] macOS：改动后 GPU 进程 CPU 回落至接近 0
- [ ] macOS：快捷键上传、托盘/设置/重命名窗口功能正常
- [ ] Windows / Linux 无回归

我本地缺少完整的构建环境，因此上述几项请以 CI 结果和你的判断为准。如果你希望我先补齐验证再合并，我可以去搭环境跑一遍。

## 提交规范说明

CONTRIBUTING 要求用 `yarn cz` 提交，但我本地没有安装依赖，因此手写了符合 gitmoji + 规范格式的 commit message（`:bug: Fix(gui): ...`）。如果格式不合要求，我可以 rebase 重提。
