### PR TITLE
:zap: Perf(gui): stop idle GPU churn from uploader status dot

### DIFF
--- a/src/renderer/components/main/dashboard/uploader-switcher.tsx
+++ b/src/renderer/components/main/dashboard/uploader-switcher.tsx
@@ -71,7 +71,8 @@ export function UploaderSwitcher({
           className="group h-10 cursor-pointer bg-card/80 px-4 backdrop-blur transition-all hover:border-primary/30"
           disabled={disabled}
         >
-          <span className="size-2 animate-pulse rounded-full bg-green-500" />
+          {/* 刻意不加 animate-pulse：2s infinite 会让主窗口空闲时也持续产出合成帧，把周围几层 backdrop-blur 一起钉在满帧率上重算，GPU 进程无法进入空闲。静态圆点表意相同。 */}
+          <span className="size-2 rounded-full bg-green-500" />
           <span className="text-sm font-semibold text-foreground transition-colors group-hover:text-primary">
             {current.providerName}
             <span className="mx-1 font-normal text-muted-foreground">/</span>


### PR DESCRIPTION
## 问题

主窗口打开后（哪怕完全不操作），`PicGo Helper (GPU)` 持续占用约 25% CPU / 16% GPU，同时 `WindowServer` 也被抬到 45%。

## 原因

Dashboard 上传器切换按钮的绿色状态点使用了 `animate-pulse`（`2s infinite`）：

```tsx
<span className="size-2 animate-pulse rounded-full bg-green-500" />
```

它本身很轻，但副作用是**让渲染进程永远退不出合成循环**——只要有动画在跑，浏览器就会按屏幕刷新率持续产出新帧（ProMotion 屏即 120fps）。

而 Dashboard 上同时叠着多层 `backdrop-filter`：

| 位置 | 模糊半径 |
|---|---|
| `picgo-app-sidebar.tsx:74` | `backdrop-blur-xl`（24px） |
| `app-main-card.tsx:20` | `backdrop-blur-xl`（24px） |
| `uploader-switcher.tsx:71` | `backdrop-blur`（8px） |
| `picgo-dashboard.tsx:137` | `backdrop-blur`（8px） |

`backdrop-filter` 缓存能力很弱，只要所在帧被合成就得重算。叠加 `windowList.ts:29` 的 `backgroundThrottling: false`（窗口被遮挡时也不降频），这个循环就一直全速跑。

## 改动

去掉 `animate-pulse`，保留静态绿点。

排查过渲染层其余部分：Dashboard 上没有 `setInterval`，没有配 `refetchInterval`，React 层无重渲染循环，`caret-blink` / `animate-spin` / skeleton 的 `animate-pulse` 都只在弹窗或加载态出现。**这个绿点是空闲态下唯一的常驻动画**，移除后合成器即可进入空闲。

静态圆点与脉冲圆点表达的语义一致（当前生效的上传器），无 i18n / 交互变更。

## 验证

- `pnpm check`（tsc + dpdm + eslint）通过
- DevTools → Rendering → Frame Rendering Stats：改动前停在 Dashboard 不操作，FPS 表持续跳动；改动后不再持续产帧
- 活动监视器：`PicGo Helper (GPU)` 与 `WindowServer` 占用回落

## 说明

本 PR 只处理空闲态。滚动相册、拖拽 / 缩放窗口等**交互态**下 `backdrop-blur-xl` 的开销不受影响——那几层模糊予以保留，因为后续要做用户自定义背景图，需要真实的透明效果。

届时模糊的对象将从纯色变成真实图片，开销会进一步上升，可以再考虑预生成模糊背景图、或下调模糊半径等方案，不在本 PR 范围内。